### PR TITLE
Feature: Sync Lists

### DIFF
--- a/twilly/src/account.rs
+++ b/twilly/src/account.rs
@@ -115,6 +115,7 @@ impl<'a> Accounts<'a> {
                 sid.unwrap_or_else(|| &self.client.config.account_sid)
             ),
             None,
+            None,
         );
 
         account
@@ -154,6 +155,7 @@ impl<'a> Accounts<'a> {
                 Method::GET,
                 "https://api.twilio.com/2010-04-01/Accounts.json?PageSize=5",
                 Some(&params),
+                None,
             )?;
 
         let mut results: Vec<Account> = accounts_page.accounts;
@@ -165,7 +167,7 @@ impl<'a> Accounts<'a> {
             );
             accounts_page =
                 self.client
-                    .send_request::<AccountPage, ()>(Method::GET, &full_url, None)?;
+                    .send_request::<AccountPage, ()>(Method::GET, &full_url, None, None)?;
 
             results.append(&mut accounts_page.accounts);
         }
@@ -195,6 +197,7 @@ impl<'a> Accounts<'a> {
             Method::POST,
             "https://api.twilio.com/2010-04-01/Accounts.json",
             Some(&params),
+            None,
         )
     }
 
@@ -232,6 +235,7 @@ impl<'a> Accounts<'a> {
                 account_sid
             ),
             Some(&opts),
+            None,
         )
     }
 }

--- a/twilly/src/conversation.rs
+++ b/twilly/src/conversation.rs
@@ -150,6 +150,7 @@ impl<'a> Conversations<'a> {
             Method::GET,
             &format!("https://conversations.twilio.com/v1/Conversations/{}", sid),
             None,
+            None,
         );
 
         conversation
@@ -187,6 +188,7 @@ impl<'a> Conversations<'a> {
             Method::GET,
             "https://conversations.twilio.com/v1/Conversations",
             Some(&params),
+            None,
         )?;
 
         let mut results: Vec<Conversation> = conversations_page.conversations;
@@ -195,6 +197,7 @@ impl<'a> Conversations<'a> {
             conversations_page = self.client.send_request::<ConversationPage, ()>(
                 Method::GET,
                 &conversations_page.meta.next_page_url.unwrap(),
+                None,
                 None,
             )?;
 
@@ -219,6 +222,7 @@ impl<'a> Conversations<'a> {
                 Method::POST,
                 &format!("https://conversations.twilio.com/v1/Conversations/{}", sid),
                 Some(&updates),
+                None,
             );
 
         conversation
@@ -231,6 +235,7 @@ impl<'a> Conversations<'a> {
         let conversation = self.client.send_request_and_ignore_response::<()>(
             Method::DELETE,
             &format!("https://conversations.twilio.com/v1/Conversations/{}", sid),
+            None,
             None,
         );
 

--- a/twilly/src/lib.rs
+++ b/twilly/src/lib.rs
@@ -274,14 +274,14 @@ impl Client {
                 .client
                 .request(method, url)
                 .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
-                .headers(headers)
+                .headers(headers.unwrap_or_default())
                 .query(&params)
                 .send(),
             _ => self
                 .client
                 .request(method, url)
                 .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
-                .headers(headers)
+                .headers(headers.unwrap_or_default())
                 .form(&params)
                 .send(),
         }

--- a/twilly/src/sync.rs
+++ b/twilly/src/sync.rs
@@ -4,6 +4,8 @@ Contains Twilio Sync related functionality.
 
 */
 pub mod documents;
+pub mod listitems;
+pub mod lists;
 pub mod mapitems;
 pub mod maps;
 pub mod services;

--- a/twilly/src/sync/documents.rs
+++ b/twilly/src/sync/documents.rs
@@ -161,10 +161,10 @@ impl<'a, 'b> Document<'a, 'b> {
     /// Targets the Sync Service provided to the `service()` argument and updates the Document
     /// provided to the `document()` argument.
     pub fn update(&self, params: UpdateParams) -> Result<SyncDocument, TwilioError> {
-        let headers = HeaderMap::new();
+        let mut headers = HeaderMap::new();
 
-        if let Some(if_match) = params.if_match {
-            headers.append("If-Match", if_match);
+        if let Some(if_match) = params.if_match.clone() {
+            headers.append("If-Match", if_match.parse().unwrap());
         }
 
         let document = self.client.send_request::<SyncDocument, UpdateParams>(
@@ -174,7 +174,7 @@ impl<'a, 'b> Document<'a, 'b> {
                 self.service_sid, self.sid
             ),
             Some(&params),
-            Some(&headers),
+            Some(headers),
         );
 
         document

--- a/twilly/src/sync/documents.rs
+++ b/twilly/src/sync/documents.rs
@@ -5,7 +5,7 @@ Contains Twilio Sync Document related functionality.
 */
 
 use crate::{Client, PageMeta, TwilioError};
-use reqwest::Method;
+use reqwest::{header::HeaderMap, Method};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
@@ -91,6 +91,7 @@ impl<'a, 'b> Documents<'a, 'b> {
                 self.service_sid
             ),
             Some(&params),
+            None,
         );
 
         document
@@ -109,6 +110,7 @@ impl<'a, 'b> Documents<'a, 'b> {
                 self.service_sid
             ),
             None,
+            None,
         )?;
 
         let mut results: Vec<SyncDocument> = documents_page.documents;
@@ -117,6 +119,7 @@ impl<'a, 'b> Documents<'a, 'b> {
             documents_page = self.client.send_request::<DocumentPage, ()>(
                 Method::GET,
                 &documents_page.meta.next_page_url.unwrap(),
+                None,
                 None,
             )?;
 
@@ -147,6 +150,7 @@ impl<'a, 'b> Document<'a, 'b> {
                 self.service_sid, self.sid
             ),
             None,
+            None,
         );
 
         document
@@ -157,6 +161,12 @@ impl<'a, 'b> Document<'a, 'b> {
     /// Targets the Sync Service provided to the `service()` argument and updates the Document
     /// provided to the `document()` argument.
     pub fn update(&self, params: UpdateParams) -> Result<SyncDocument, TwilioError> {
+        let headers = HeaderMap::new();
+
+        if let Some(if_match) = params.if_match {
+            headers.append("If-Match", if_match);
+        }
+
         let document = self.client.send_request::<SyncDocument, UpdateParams>(
             Method::POST,
             &format!(
@@ -164,6 +174,7 @@ impl<'a, 'b> Document<'a, 'b> {
                 self.service_sid, self.sid
             ),
             Some(&params),
+            Some(&headers),
         );
 
         document
@@ -180,6 +191,7 @@ impl<'a, 'b> Document<'a, 'b> {
                 "https://sync.twilio.com/v1/Services/{}/Documents/{}",
                 self.service_sid, self.sid
             ),
+            None,
             None,
         );
 

--- a/twilly/src/sync/listitems.rs
+++ b/twilly/src/sync/listitems.rs
@@ -5,7 +5,7 @@ Contains Twilio Sync List Item related functionality.
 */
 
 use crate::{Client, PageMeta, TwilioError};
-use reqwest::Method;
+use reqwest::{header::HeaderMap, Method};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
@@ -180,10 +180,10 @@ impl<'a, 'b> ListItem<'a, 'b> {
     /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`
     /// argument and updates the item with the index provided to `listitem()` with the parameters.
     pub fn update(&self, params: UpdateParams) -> Result<SyncListItem, TwilioError> {
-        let headers = HeaderMap::new();
+        let mut headers = HeaderMap::new();
 
-        if let Some(if_match) = params.if_match {
-            headers.append("If-Match", if_match);
+        if let Some(if_match) = params.if_match.clone() {
+            headers.append("If-Match", if_match.parse().unwrap());
         }
 
         let list_item = self.client.send_request::<SyncListItem, UpdateParams>(

--- a/twilly/src/sync/listitems.rs
+++ b/twilly/src/sync/listitems.rs
@@ -124,7 +124,7 @@ impl<'a, 'b> ListItems<'a, 'b> {
         let mut list_items_page = self.client.send_request::<ListItemPage, ListParams>(
             Method::GET,
             &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items?PageSize=50",
+                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items?PageSize=50",
                 self.service_sid, self.list_sid
             ),
             Some(&params),

--- a/twilly/src/sync/listitems.rs
+++ b/twilly/src/sync/listitems.rs
@@ -1,0 +1,219 @@
+/*!
+
+Contains Twilio Sync List Item related functionality.
+
+*/
+
+use crate::{Client, PageMeta, TwilioError};
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use serde_with::skip_serializing_none;
+
+/// Represents a page of Sync List Items from the Twilio API.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+pub struct ListItemPage {
+    items: Vec<SyncListItem>,
+    meta: PageMeta,
+}
+
+/// A Sync List Item resource.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncListItem {
+    pub index: u32,
+    pub account_sid: String,
+    pub service_sid: String,
+    pub list_sid: String,
+    pub url: String,
+    pub data: Value,
+    pub date_created: String,
+    pub date_updated: String,
+    pub date_expires: Option<String>,
+    /// Identity of the creator. Uses the identity of the
+    /// respective client or defaults to `system` if created via REST.
+    pub created_by: String,
+    pub revision: String,
+}
+
+/// Parameters for creating a Sync List Item
+#[skip_serializing_none]
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+pub struct CreateParams {
+    data: Value,
+    /// How long the List Item should exist before deletion (in seconds).
+    ttl: Option<u16>,
+    /// How long the *parent* List resource should exist before deletion (in seconds).
+    collection_ttl: Option<u16>,
+}
+
+#[derive(Serialize)]
+pub enum Order {
+    Asc,
+    Desc,
+}
+
+/// See `ListParams`
+#[derive(Serialize)]
+pub enum Bounds {
+    Inclusive,
+    Exclusive,
+}
+
+/// Arguments for listing Sync Map Items
+#[skip_serializing_none]
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+pub struct ListParams {
+    pub order: Option<Order>,
+    // The key of the first Map Item to read.
+    pub from: Option<String>,
+    /// Whether to include the Map Item described by the `from` parameter. Defaults to inclusive.
+    pub bounds: Option<Bounds>,
+}
+
+/// Parameters for updating a Sync Map Item
+#[skip_serializing_none]
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+pub struct UpdateParams {
+    #[serde(rename(serialize = "If-Match"))]
+    if_match: Option<String>,
+    data: Value,
+    /// How long the Map Item should exist before deletion (in seconds).
+    ttl: Option<u16>,
+    /// How long the *parent* Map resource should exist before deletion (in seconds). Can only be used
+    /// if the `data` or `ttl` is updated in the same request.
+    collection_ttl: Option<u16>,
+}
+
+pub struct ListItems<'a, 'b> {
+    pub client: &'a Client,
+    pub service_sid: &'b str,
+    pub list_sid: &'b str,
+}
+
+impl<'a, 'b> ListItems<'a, 'b> {
+    /// [Creates a Sync List Item](https://www.twilio.com/docs/sync/api/listitem-resource#create-a-listitem-resource)
+    ///
+    /// Creates a Sync List Item with the provided parameters.
+    pub fn create(&self, params: CreateParams) -> Result<SyncListItem, TwilioError> {
+        let list_item = self.client.send_request::<SyncListItem, CreateParams>(
+            Method::POST,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items",
+                self.service_sid, self.list_sid
+            ),
+            Some(&params),
+            None,
+        );
+
+        list_item
+    }
+
+    /// [Lists Sync List Items](https://www.twilio.com/docs/sync/api/listitem-resource#read-multiple-listitem-resources)
+    ///
+    /// List Sync List Items In the targeted Service and List.
+    ///
+    /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`
+    /// argument and lists all List items.
+    ///
+    /// List items will be _eagerly_ paged until all retrieved.
+    pub fn list(&self, params: ListParams) -> Result<Vec<SyncListItem>, TwilioError> {
+        let mut list_items_page = self.client.send_request::<ListItemPage, ListParams>(
+            Method::GET,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items?PageSize=50",
+                self.service_sid, self.list_sid
+            ),
+            Some(&params),
+            None,
+        )?;
+
+        let mut results: Vec<SyncListItem> = list_items_page.items;
+
+        while (list_items_page.meta.next_page_url).is_some() {
+            list_items_page = self.client.send_request::<ListItemPage, ListParams>(
+                Method::GET,
+                &list_items_page.meta.next_page_url.unwrap(),
+                None,
+                None,
+            )?;
+
+            results.append(&mut list_items_page.items);
+        }
+
+        Ok(results)
+    }
+}
+
+pub struct ListItem<'a, 'b> {
+    pub client: &'a Client,
+    pub service_sid: &'b str,
+    pub list_sid: &'b str,
+    /// Index of the Sync List Item
+    pub index: &'b u32,
+}
+
+impl<'a, 'b> ListItem<'a, 'b> {
+    /// [Gets a Sync List Item](https://www.twilio.com/docs/sync/api/listitem-resource#fetch-a-listitem-resource)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`
+    /// argument and fetches the item with the index provided to `listitem()`.
+    pub fn get(&self) -> Result<SyncListItem, TwilioError> {
+        let list_item = self.client.send_request::<SyncListItem, ()>(
+            Method::GET,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
+                self.service_sid, self.list_sid, self.index
+            ),
+            None,
+            None,
+        );
+
+        list_item
+    }
+
+    /// [Update a Sync List Item](https://www.twilio.com/docs/sync/api/listitem-resource#update-a-listitem-resource)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`
+    /// argument and updates the item with the index provided to `listitem()` with the parameters.
+    pub fn update(&self, params: UpdateParams) -> Result<SyncListItem, TwilioError> {
+        let headers = HeaderMap::new();
+
+        if let Some(if_match) = params.if_match {
+            headers.append("If-Match", if_match);
+        }
+
+        let list_item = self.client.send_request::<SyncListItem, UpdateParams>(
+            Method::POST,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
+                self.service_sid, self.list_sid, self.index
+            ),
+            Some(&params),
+            Some(headers),
+        );
+
+        list_item
+    }
+
+    /// [Deletes a Sync List Item](https://www.twilio.com/docs/sync/api/listitem-resource#delete-a-listitem-resource)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`
+    /// argument and deletes the item with the index provided to `listitem()`.
+    pub fn delete(&self) -> Result<(), TwilioError> {
+        let list_item = self.client.send_request_and_ignore_response::<()>(
+            Method::DELETE,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
+                self.service_sid, self.list_sid, self.index
+            ),
+            None,
+            None,
+        );
+
+        list_item
+    }
+}

--- a/twilly/src/sync/lists.rs
+++ b/twilly/src/sync/lists.rs
@@ -1,0 +1,213 @@
+/*!
+
+Contains Twilio Sync List related functionality.
+
+*/
+
+use crate::{Client, PageMeta, TwilioError};
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use super::listitems::{ListItem, ListItems};
+
+/// Represents a page of Sync Lists from the Twilio API.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+pub struct SyncListPage {
+    lists: Vec<SyncList>,
+    meta: PageMeta,
+}
+
+/// A Sync List resource.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SyncList {
+    pub sid: String,
+    pub unique_name: String,
+    pub account_sid: String,
+    pub service_sid: String,
+    pub url: String,
+    pub date_created: String,
+    pub date_updated: String,
+    pub date_expires: Option<String>,
+    /// Identity of the creator. Uses the identity of the
+    /// respective client or defaults to `system` if created via REST.
+    pub created_by: String,
+    pub links: Links,
+    pub revision: String,
+}
+
+/// Resources _linked_ to a Sync List
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct Links {
+    pub items: String,
+    pub permissions: String,
+}
+
+impl Default for Links {
+    fn default() -> Self {
+        Links {
+            items: String::from(""),
+            permissions: String::from(""),
+        }
+    }
+}
+
+/// Parameters for creating a Sync List
+#[skip_serializing_none]
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+pub struct CreateParams {
+    unique_name: Option<String>,
+    ttl: Option<bool>,
+}
+
+/// Parameters for updating a Sync List
+#[skip_serializing_none]
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+pub struct UpdateParams {
+    ttl: Option<bool>,
+}
+
+pub struct Lists<'a, 'b> {
+    pub client: &'a Client,
+    pub service_sid: &'b str,
+}
+
+impl<'a, 'b> Lists<'a, 'b> {
+    /// [Creates a Sync List resource](https://www.twilio.com/docs/sync/api/list-resource#create-a-list-resource)
+    ///
+    /// Creates a Sync List resource with the provided parameters.
+    pub fn create(&self, params: CreateParams) -> Result<SyncList, TwilioError> {
+        let list = self.client.send_request::<SyncList, CreateParams>(
+            Method::POST,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists",
+                &self.service_sid
+            ),
+            Some(&params),
+            None,
+        );
+
+        list
+    }
+
+    /// [Lists Sync Lists](https://www.twilio.com/docs/sync/api/list-resource#read-multiple-list-resources)
+    ///
+    /// Lists Sync Lists existing on the Twilio account.
+    ///
+    /// Lists will be _eagerly_ paged until all retrieved.
+    pub fn list(&self) -> Result<Vec<SyncList>, TwilioError> {
+        let mut lists_page = self.client.send_request::<SyncListPage, ()>(
+            Method::GET,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists?PageSize=50",
+                self.service_sid
+            ),
+            None,
+            None,
+        )?;
+
+        let mut results: Vec<SyncList> = lists_page.maps;
+
+        while (lists_page.meta.next_page_url).is_some() {
+            lists_page = self.client.send_request::<SyncListPage, ()>(
+                Method::GET,
+                &lists_page.meta.next_page_url.unwrap(),
+                None,
+                None,
+            )?;
+
+            results.append(&mut lists_page.maps);
+        }
+
+        Ok(results)
+    }
+}
+
+pub struct List<'a, 'b> {
+    pub client: &'a Client,
+    pub service_sid: &'b str,
+    /// SID of the Sync List. Can also be it's unique name.
+    pub sid: &'b str,
+}
+
+impl<'a, 'b> List<'a, 'b> {
+    /// [Gets a Sync List](https://www.twilio.com/docs/sync/api/list-resource#fetch-a-list-resource)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument and fetches the List
+    /// provided to the `list()` argument.
+    pub fn get(&self) -> Result<SyncList, TwilioError> {
+        let list = self.client.send_request::<SyncList, ()>(
+            Method::GET,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists/{}",
+                self.service_sid, self.sid
+            ),
+            None,
+            None,
+        );
+
+        list
+    }
+
+    /// [Update a Sync List](https://www.twilio.com/docs/sync/api/list-resource#update-a-list-resource)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument  and updates the List
+    /// provided to the `list()` argument.
+    pub fn update(&self, params: UpdateParams) -> Result<SyncList, TwilioError> {
+        let list = self.client.send_request::<SyncList, UpdateParams>(
+            Method::POST,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists/{}",
+                self.service_sid, self.sid
+            ),
+            Some(&params),
+            None,
+        );
+
+        list
+    }
+
+    /// [Deletes a Sync List](https://www.twilio.com/docs/sync/api/list-resource#delete-a-list-resource)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument and deletes the List
+    /// provided to the `list()` argument.
+    ///
+    /// This will delete any Sync List items underneath this list.
+    pub fn delete(&self) -> Result<(), TwilioError> {
+        let list = self.client.send_request_and_ignore_response::<()>(
+            Method::DELETE,
+            &format!(
+                "https://sync.twilio.com/v1/Services/{}/Lists/{}",
+                self.service_sid, self.sid
+            ),
+            None,
+            None,
+        );
+
+        list
+    }
+
+    /// Functions relating to a known Sync List Item.
+    ///
+    /// Takes in the key of the Sync List Item to perform actions against.
+    pub fn listitem(&'a self, key: &'b str) -> MapItem {
+        MapItem {
+            client: self.client,
+            service_sid: self.service_sid,
+            map_sid: self.sid,
+            key,
+        }
+    }
+
+    /// General Sync Map Item functions.
+    pub fn listitems(&'a self) -> MapItems {
+        MapItems {
+            client: self.client,
+            service_sid: self.service_sid,
+            map_sid: self.sid,
+        }
+    }
+}

--- a/twilly/src/sync/lists.rs
+++ b/twilly/src/sync/lists.rs
@@ -109,7 +109,7 @@ impl<'a, 'b> Lists<'a, 'b> {
             None,
         )?;
 
-        let mut results: Vec<SyncList> = lists_page.maps;
+        let mut results: Vec<SyncList> = lists_page.lists;
 
         while (lists_page.meta.next_page_url).is_some() {
             lists_page = self.client.send_request::<SyncListPage, ()>(
@@ -119,7 +119,7 @@ impl<'a, 'b> Lists<'a, 'b> {
                 None,
             )?;
 
-            results.append(&mut lists_page.maps);
+            results.append(&mut lists_page.lists);
         }
 
         Ok(results)
@@ -193,21 +193,21 @@ impl<'a, 'b> List<'a, 'b> {
     /// Functions relating to a known Sync List Item.
     ///
     /// Takes in the key of the Sync List Item to perform actions against.
-    pub fn listitem(&'a self, key: &'b str) -> MapItem {
-        MapItem {
+    pub fn listitem(&'a self, index: &'b u32) -> ListItem {
+        ListItem {
             client: self.client,
             service_sid: self.service_sid,
-            map_sid: self.sid,
-            key,
+            list_sid: self.sid,
+            index,
         }
     }
 
     /// General Sync Map Item functions.
-    pub fn listitems(&'a self) -> MapItems {
-        MapItems {
+    pub fn listitems(&'a self) -> ListItems {
+        ListItems {
             client: self.client,
             service_sid: self.service_sid,
-            map_sid: self.sid,
+            list_sid: self.sid,
         }
     }
 }

--- a/twilly/src/sync/mapitems.rs
+++ b/twilly/src/sync/mapitems.rs
@@ -205,7 +205,7 @@ impl<'a, 'b> MapItem<'a, 'b> {
     /// Targets the Sync Service provided to the `service()` argument, the Map provided to the `map()`
     /// argument and deletes the item with the key provided to `mapitem()`.
     pub fn delete(&self) -> Result<(), TwilioError> {
-        let service = self.client.send_request_and_ignore_response::<()>(
+        let map_item = self.client.send_request_and_ignore_response::<()>(
             Method::DELETE,
             &format!(
                 "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items/{}",
@@ -215,6 +215,6 @@ impl<'a, 'b> MapItem<'a, 'b> {
             None,
         );
 
-        service
+        map_item
     }
 }

--- a/twilly/src/sync/mapitems.rs
+++ b/twilly/src/sync/mapitems.rs
@@ -5,7 +5,7 @@ Contains Twilio Sync Map Item related functionality.
 */
 
 use crate::{Client, PageMeta, TwilioError};
-use reqwest::Method;
+use reqwest::{header::HeaderMap, Method};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
@@ -181,10 +181,10 @@ impl<'a, 'b> MapItem<'a, 'b> {
     /// Targets the Sync Service provided to the `service()` argument, the Map provided to the `map()`
     /// argument and updates the item with the key provided to `mapitem()` with the parameters.
     pub fn update(&self, params: UpdateParams) -> Result<SyncMapItem, TwilioError> {
-        let headers = HeaderMap::new();
+        let mut headers = HeaderMap::new();
 
-        if let Some(if_match) = params.if_match {
-            headers.append("If-Match", if_match);
+        if let Some(if_match) = params.if_match.clone() {
+            headers.append("If-Match", if_match.parse().unwrap());
         }
 
         let map_item = self.client.send_request::<SyncMapItem, UpdateParams>(

--- a/twilly/src/sync/mapitems.rs
+++ b/twilly/src/sync/mapitems.rs
@@ -107,6 +107,7 @@ impl<'a, 'b> MapItems<'a, 'b> {
                 self.service_sid, self.map_sid
             ),
             Some(&params),
+            None,
         );
 
         map_item
@@ -128,6 +129,7 @@ impl<'a, 'b> MapItems<'a, 'b> {
                 self.service_sid, self.map_sid
             ),
             Some(&params),
+            None,
         )?;
 
         let mut results: Vec<SyncMapItem> = map_items_page.items;
@@ -136,6 +138,7 @@ impl<'a, 'b> MapItems<'a, 'b> {
             map_items_page = self.client.send_request::<MapItemPage, ListParams>(
                 Method::GET,
                 &map_items_page.meta.next_page_url.unwrap(),
+                None,
                 None,
             )?;
 
@@ -167,6 +170,7 @@ impl<'a, 'b> MapItem<'a, 'b> {
                 self.service_sid, self.map_sid, self.key
             ),
             None,
+            None,
         );
 
         map_item
@@ -177,6 +181,12 @@ impl<'a, 'b> MapItem<'a, 'b> {
     /// Targets the Sync Service provided to the `service()` argument, the Map provided to the `map()`
     /// argument and updates the item with the key provided to `mapitem()` with the parameters.
     pub fn update(&self, params: UpdateParams) -> Result<SyncMapItem, TwilioError> {
+        let headers = HeaderMap::new();
+
+        if let Some(if_match) = params.if_match {
+            headers.append("If-Match", if_match);
+        }
+
         let map_item = self.client.send_request::<SyncMapItem, UpdateParams>(
             Method::POST,
             &format!(
@@ -184,6 +194,7 @@ impl<'a, 'b> MapItem<'a, 'b> {
                 self.service_sid, self.map_sid, self.key
             ),
             Some(&params),
+            Some(headers),
         );
 
         map_item
@@ -200,6 +211,7 @@ impl<'a, 'b> MapItem<'a, 'b> {
                 "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items/{}",
                 self.service_sid, self.map_sid, self.key
             ),
+            None,
             None,
         );
 

--- a/twilly/src/sync/maps.rs
+++ b/twilly/src/sync/maps.rs
@@ -87,6 +87,7 @@ impl<'a, 'b> Maps<'a, 'b> {
                 &self.service_sid
             ),
             Some(&params),
+            None,
         );
 
         map
@@ -105,6 +106,7 @@ impl<'a, 'b> Maps<'a, 'b> {
                 self.service_sid
             ),
             None,
+            None,
         )?;
 
         let mut results: Vec<SyncMap> = maps_page.maps;
@@ -113,6 +115,7 @@ impl<'a, 'b> Maps<'a, 'b> {
             maps_page = self.client.send_request::<SyncMapPage, ()>(
                 Method::GET,
                 &maps_page.meta.next_page_url.unwrap(),
+                None,
                 None,
             )?;
 
@@ -143,6 +146,7 @@ impl<'a, 'b> Map<'a, 'b> {
                 self.service_sid, self.sid
             ),
             None,
+            None,
         );
 
         map
@@ -160,6 +164,7 @@ impl<'a, 'b> Map<'a, 'b> {
                 self.service_sid, self.sid
             ),
             Some(&params),
+            None,
         );
 
         map
@@ -178,6 +183,7 @@ impl<'a, 'b> Map<'a, 'b> {
                 "https://sync.twilio.com/v1/Services/{}/Maps/{}",
                 self.service_sid, self.sid
             ),
+            None,
             None,
         );
 

--- a/twilly/src/sync/services.rs
+++ b/twilly/src/sync/services.rs
@@ -11,6 +11,7 @@ use serde_with::skip_serializing_none;
 
 use super::{
     documents::{Document, Documents},
+    lists::{List, Lists},
     maps::{Map, Maps},
 };
 
@@ -238,6 +239,25 @@ impl<'a, 'b> Service<'a, 'b> {
         Maps {
             client: self.client,
             service_sid: self.sid,
+        }
+    }
+
+    /// General Sync List functions.
+    pub fn lists(&'a self) -> Lists {
+        Lists {
+            client: self.client,
+            service_sid: self.sid,
+        }
+    }
+
+    /// Functions relating to a known Sync List.
+    ///
+    /// Takes in the SID of the Sync List to perform actions against.
+    pub fn list(&'a self, sid: &'b str) -> List {
+        List {
+            client: self.client,
+            service_sid: self.sid,
+            sid,
         }
     }
 }

--- a/twilly/src/sync/services.rs
+++ b/twilly/src/sync/services.rs
@@ -106,6 +106,7 @@ impl<'a> Services<'a> {
                 Method::POST,
                 "https://sync.twilio.com/v1/Services",
                 Some(&params),
+                None,
             );
 
         service
@@ -121,6 +122,7 @@ impl<'a> Services<'a> {
             Method::GET,
             "https://sync.twilio.com/v1/Services?PageSize=20",
             None,
+            None,
         )?;
 
         let mut results: Vec<SyncService> = services_page.services;
@@ -129,6 +131,7 @@ impl<'a> Services<'a> {
             services_page = self.client.send_request::<SyncServicePage, ()>(
                 Method::GET,
                 &services_page.meta.next_page_url.unwrap(),
+                None,
                 None,
             )?;
 
@@ -152,6 +155,7 @@ impl<'a, 'b> Service<'a, 'b> {
         let service = self.client.send_request::<SyncService, ()>(
             Method::GET,
             &format!("https://sync.twilio.com/v1/Services/{}", self.sid),
+            None,
             None,
         );
 
@@ -178,6 +182,7 @@ impl<'a, 'b> Service<'a, 'b> {
                 Method::POST,
                 &format!("https://sync.twilio.com/v1/Services/{}", self.sid),
                 Some(&params),
+                None,
             );
 
         service
@@ -191,6 +196,7 @@ impl<'a, 'b> Service<'a, 'b> {
         let service = self.client.send_request_and_ignore_response::<()>(
             Method::DELETE,
             &format!("https://sync.twilio.com/v1/Services/{}", self.sid),
+            None,
             None,
         );
 

--- a/twilly_cli/src/sync.rs
+++ b/twilly_cli/src/sync.rs
@@ -1,4 +1,6 @@
 mod documents;
+mod listitems;
+mod lists;
 mod mapitems;
 mod maps;
 
@@ -16,6 +18,8 @@ pub enum Action {
     Document,
     #[strum(to_string = "Maps")]
     Map,
+    #[strum(to_string = "Lists")]
+    List,
     #[strum(to_string = "List Details")]
     ListDetails,
     Delete,
@@ -120,6 +124,7 @@ pub fn choose_sync_resource(twilio: &Client) {
                     documents::choose_document_action(&twilio, selected_sync_service)
                 }
                 Action::Map => maps::choose_map_action(&twilio, selected_sync_service),
+                Action::List => lists::choose_list_action(&twilio, selected_sync_service),
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_service);
                     println!()

--- a/twilly_cli/src/sync/listitems.rs
+++ b/twilly_cli/src/sync/listitems.rs
@@ -1,0 +1,108 @@
+use std::process;
+
+use inquire::{Confirm, Select};
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{
+    sync::{listitems::ListParams, lists::SyncList, services::SyncService},
+    Client,
+};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+
+#[derive(Debug, Clone, Display, EnumIter, EnumString)]
+pub enum Action {
+    #[strum(to_string = "List Details")]
+    ListDetails,
+    Delete,
+    Back,
+    Exit,
+}
+
+pub fn choose_list_item_action(twilio: &Client, sync_service: &SyncService, list: &SyncList) {
+    let mut sync_list_items = twilio
+        .sync()
+        .service(&sync_service.sid)
+        .list(&list.sid)
+        .listitems()
+        .list(ListParams {
+            order: None,
+            bounds: None,
+            from: None,
+        })
+        .unwrap_or_else(|error| panic!("{}", error));
+
+    if sync_list_items.len() == 0 {
+        println!("No Sync List items found.");
+        return;
+    }
+
+    println!("Found {} Sync List items.", sync_list_items.len());
+
+    let mut selected_sync_list_index: Option<usize> = None;
+    loop {
+        let selected_sync_list_item = if let Some(index) = selected_sync_list_index {
+            &mut sync_list_items[index]
+        } else {
+            if let Some(action_choice) = get_action_choice_from_user(
+                sync_list_items
+                    .iter()
+                    .map(|list_item| format!("{}", list_item.index))
+                    .collect::<Vec<String>>(),
+                "Choose a Sync List item: ",
+            ) {
+                match action_choice {
+                    ActionChoice::Back => {
+                        break;
+                    }
+                    ActionChoice::Exit => process::exit(0),
+                    ActionChoice::Other(choice) => {
+                        let sync_list_position = sync_list_items
+                            .iter()
+                            .position(|list| list.index.to_string() == choice)
+                            .expect("Could not find Sync List in existing Sync Map list");
+
+                        selected_sync_list_index = Some(sync_list_position);
+                        &mut sync_list_items[sync_list_position]
+                    }
+                }
+            } else {
+                break;
+            }
+        };
+
+        let options: Vec<Action> = Action::iter().collect();
+        let resource_selection_prompt = Select::new("Select an action:", options.clone());
+        if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
+            match resource {
+                Action::ListDetails => {
+                    println!("{:#?}", selected_sync_list_item);
+                    println!()
+                }
+                Action::Delete => {
+                    let confirm_prompt = Confirm::new(
+                        "Are you sure to wish to delete the Sync List item? (Yes / No)",
+                    );
+                    let confirmation = prompt_user(confirm_prompt);
+                    if confirmation.is_some() && confirmation.unwrap() == true {
+                        println!("Deleting Sync Map item...");
+                        twilio
+                            .sync()
+                            .service(&sync_service.sid)
+                            .list(&list.sid)
+                            .listitem(&selected_sync_list_item.index)
+                            .delete()
+                            .unwrap_or_else(|error| panic!("{}", error));
+                        sync_list_items.remove(selected_sync_list_index.expect(
+                            "Could not find Sync List item in existing Sync List items list",
+                        ));
+                        println!("Sync List item deleted.");
+                        println!();
+                        break;
+                    }
+                }
+                Action::Back => break,
+                Action::Exit => process::exit(0),
+            }
+        }
+    }
+}

--- a/twilly_cli/src/sync/lists.rs
+++ b/twilly_cli/src/sync/lists.rs
@@ -1,0 +1,107 @@
+use std::process;
+
+use inquire::{Confirm, Select};
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{sync::services::SyncService, Client};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+
+use crate::sync::listitems;
+
+#[derive(Debug, Clone, Display, EnumIter, EnumString)]
+pub enum Action {
+    #[strum(to_string = "List Items")]
+    ListItem,
+    #[strum(to_string = "List Details")]
+    ListDetails,
+    Delete,
+    Back,
+    Exit,
+}
+
+pub fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
+    let mut sync_lists = twilio
+        .sync()
+        .service(&sync_service.sid)
+        .lists()
+        .list()
+        .unwrap_or_else(|error| panic!("{}", error));
+
+    if sync_lists.len() == 0 {
+        println!("No Sync Lists found.");
+        return;
+    }
+
+    println!("Found {} Sync Lists.", sync_lists.len());
+
+    let mut selected_sync_list_index: Option<usize> = None;
+    loop {
+        let selected_sync_list = if let Some(index) = selected_sync_list_index {
+            &mut sync_lists[index]
+        } else {
+            if let Some(action_choice) = get_action_choice_from_user(
+                sync_lists
+                    .iter()
+                    .map(|list| format!("({}) {}", list.sid, list.unique_name))
+                    .collect::<Vec<String>>(),
+                "Choose a Sync List: ",
+            ) {
+                match action_choice {
+                    ActionChoice::Back => {
+                        break;
+                    }
+                    ActionChoice::Exit => process::exit(0),
+                    ActionChoice::Other(choice) => {
+                        let sync_list_position = sync_lists
+                            .iter()
+                            .position(|list| list.sid == choice[1..35])
+                            .expect("Could not find Sync List in existing Sync Map list");
+
+                        selected_sync_list_index = Some(sync_list_position);
+                        &mut sync_lists[sync_list_position]
+                    }
+                }
+            } else {
+                break;
+            }
+        };
+
+        let options: Vec<Action> = Action::iter().collect();
+        let resource_selection_prompt = Select::new("Select an action:", options.clone());
+        if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
+            match resource {
+                Action::ListItem => {
+                    listitems::choose_list_item_action(&twilio, sync_service, &selected_sync_list)
+                }
+
+                Action::ListDetails => {
+                    println!("{:#?}", selected_sync_list);
+                    println!()
+                }
+                Action::Delete => {
+                    let confirm_prompt =
+                        Confirm::new("Are you sure to wish to delete the Sync List? (Yes / No)");
+                    let confirmation = prompt_user(confirm_prompt);
+                    if confirmation.is_some() && confirmation.unwrap() == true {
+                        println!("Deleting Sync List...");
+                        twilio
+                            .sync()
+                            .service(&sync_service.sid)
+                            .list(&selected_sync_list.sid)
+                            .delete()
+                            .unwrap_or_else(|error| panic!("{}", error));
+                        sync_lists.remove(
+                            selected_sync_list_index
+                                .expect("Could not find Sync List in existing Sync Maps list"),
+                        );
+                        println!("Sync List deleted.");
+                        println!();
+                        break;
+                    }
+                }
+                Action::Back => break,
+                Action::Exit => process::exit(0),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds Sync List API coverage to Twilly & the ability to browse Sync Lists & List items in Twilly CLI.

This PR also alters the `If-Match` directive which Sync supports to correctly use the appropriate header rather than previously sending as a query param or in the request body