### PR TITLE
Refactor: Async support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,7 +1351,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twilly"
-version = "0.0.4"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "openssl",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "twilly_cli"
-version = "0.0.4"
+version = "0.1.0"
 dependencies = [
  "chrono",
  "confy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,12 +315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
-name = "futures-io"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
-
-[[package]]
 name = "futures-sink"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,12 +333,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -400,12 +391,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -701,16 +686,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1260,15 +1235,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.48.0",
@@ -1375,6 +1349,7 @@ dependencies = [
  "serde_with",
  "strum",
  "strum_macros",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1362,6 +1374,7 @@ dependencies = [
  "openssl",
  "strum",
  "strum_macros",
+ "tokio",
  "twilly",
 ]
 

--- a/twilly/Cargo.toml
+++ b/twilly/Cargo.toml
@@ -17,10 +17,11 @@ rust-version = "1.74.1"
 
 [dependencies]
 chrono = "0.4.31"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.2"
 serde_with = "3.6.0"
 strum = "0.26.1"
 strum_macros = "0.26.1"
 openssl = { version = "0.10", features = ["vendored"] }
+tokio = "1.37.0"

--- a/twilly/Cargo.toml
+++ b/twilly/Cargo.toml
@@ -2,7 +2,7 @@
 name = "twilly"
 version = "0.0.4"
 edition = "2021"
-description = "A *synchronous* implementation of the Twilio API in Rust built upon Reqwest and Serde"
+description = "A implementation of the Twilio API in Rust built upon Reqwest and Serde"
 authors = ["Tristan Blackwell"]
 repository = "https://github.com/TristanBlackwell/twilly"
 homepage = "https://github.com/TristanBlackwell/twilly"

--- a/twilly/Cargo.toml
+++ b/twilly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twilly"
-version = "0.0.4"
+version = "0.1.0"
 edition = "2021"
 description = "A implementation of the Twilio API in Rust built upon Reqwest and Serde"
 authors = ["Tristan Blackwell"]

--- a/twilly/README.md
+++ b/twilly/README.md
@@ -1,7 +1,7 @@
 
 ## twilly
 
-`twilly` is a *synchronous* helper library bringing access to Twilio's API's via Rust. The library supports a client-based approach, instantiating a twilio client with credentials before sending & receiving requests.
+`twilly` is a helper library bringing access to Twilio's API's via Rust. The library supports a client-based approach, instantiating a twilio client with credentials before sending & receiving requests.
 
 ```rust
 let config =  TwilioConfig {

--- a/twilly/src/account.rs
+++ b/twilly/src/account.rs
@@ -107,16 +107,19 @@ impl<'a> Accounts<'a> {
     ///
     /// Takes in an optional `sid` argument otherwise will default to the current config
     /// account SID.
-    pub fn get(&self, sid: Option<&str>) -> Result<Account, TwilioError> {
-        let account = self.client.send_request::<Account, ()>(
-            Method::GET,
-            &format!(
-                "https://api.twilio.com/2010-04-01/Accounts/{}.json",
-                sid.unwrap_or_else(|| &self.client.config.account_sid)
-            ),
-            None,
-            None,
-        );
+    pub async fn get(&self, sid: Option<&str>) -> Result<Account, TwilioError> {
+        let account = self
+            .client
+            .send_request::<Account, ()>(
+                Method::GET,
+                &format!(
+                    "https://api.twilio.com/2010-04-01/Accounts/{}.json",
+                    sid.unwrap_or_else(|| &self.client.config.account_sid)
+                ),
+                None,
+                None,
+            )
+            .await;
 
         account
     }
@@ -131,7 +134,7 @@ impl<'a> Accounts<'a> {
     /// Takes optional parameters:
     /// - `friendly_name` - Return only accounts matching this friendly name
     /// - `status` - Return only accounts that match this status
-    pub fn list(
+    pub async fn list(
         &self,
         friendly_name: Option<&str>,
         status: Option<&Status>,
@@ -156,7 +159,8 @@ impl<'a> Accounts<'a> {
                 "https://api.twilio.com/2010-04-01/Accounts.json?PageSize=5",
                 Some(&params),
                 None,
-            )?;
+            )
+            .await?;
 
         let mut results: Vec<Account> = accounts_page.accounts;
 
@@ -165,9 +169,10 @@ impl<'a> Accounts<'a> {
                 "https://api.twilio.com{}",
                 accounts_page.next_page_uri.unwrap()
             );
-            accounts_page =
-                self.client
-                    .send_request::<AccountPage, ()>(Method::GET, &full_url, None, None)?;
+            accounts_page = self
+                .client
+                .send_request::<AccountPage, ()>(Method::GET, &full_url, None, None)
+                .await?;
 
             results.append(&mut accounts_page.accounts);
         }
@@ -184,7 +189,7 @@ impl<'a> Accounts<'a> {
     /// - Trial accounts can only have a single sub-account beneath it.
     ///
     /// See documentation for detail.
-    pub fn create(&self, friendly_name: Option<&str>) -> Result<Account, TwilioError> {
+    pub async fn create(&self, friendly_name: Option<&str>) -> Result<Account, TwilioError> {
         let params = CreateParams {
             friendly_name: if let Some(friendly_name) = friendly_name {
                 Some(friendly_name.to_string())
@@ -193,12 +198,14 @@ impl<'a> Accounts<'a> {
             },
         };
 
-        self.client.send_request::<Account, CreateParams>(
-            Method::POST,
-            "https://api.twilio.com/2010-04-01/Accounts.json",
-            Some(&params),
-            None,
-        )
+        self.client
+            .send_request::<Account, CreateParams>(
+                Method::POST,
+                "https://api.twilio.com/2010-04-01/Accounts.json",
+                Some(&params),
+                None,
+            )
+            .await
     }
 
     /// [Updates an account resource](https://www.twilio.com/docs/iam/api/account#update-an-account-resource)
@@ -209,7 +216,7 @@ impl<'a> Accounts<'a> {
     /// Takes optional parameters:
     /// - `friendly_name` - Update the friendly name to the provided value
     /// - `status` - Change the account status
-    pub fn update(
+    pub async fn update(
         &self,
         account_sid: &str,
         friendly_name: Option<&str>,
@@ -228,14 +235,16 @@ impl<'a> Accounts<'a> {
             },
         };
 
-        self.client.send_request::<Account, ListOrUpdateParams>(
-            Method::POST,
-            &format!(
-                "https://api.twilio.com/2010-04-01/Accounts/{}.json",
-                account_sid
-            ),
-            Some(&opts),
-            None,
-        )
+        self.client
+            .send_request::<Account, ListOrUpdateParams>(
+                Method::POST,
+                &format!(
+                    "https://api.twilio.com/2010-04-01/Accounts/{}.json",
+                    account_sid
+                ),
+                Some(&opts),
+                None,
+            )
+            .await
     }
 }

--- a/twilly/src/conversation.rs
+++ b/twilly/src/conversation.rs
@@ -145,13 +145,16 @@ impl<'a> Conversations<'a> {
     /// [Gets a Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource#fetch-a-conversation-resource)
     ///
     /// Takes in a `sid` argument which can also be the Conversations `uniqueName`.
-    pub fn get(&self, sid: &str) -> Result<Conversation, TwilioError> {
-        let conversation = self.client.send_request::<Conversation, ()>(
-            Method::GET,
-            &format!("https://conversations.twilio.com/v1/Conversations/{}", sid),
-            None,
-            None,
-        );
+    pub async fn get(&self, sid: &str) -> Result<Conversation, TwilioError> {
+        let conversation = self
+            .client
+            .send_request::<Conversation, ()>(
+                Method::GET,
+                &format!("https://conversations.twilio.com/v1/Conversations/{}", sid),
+                None,
+                None,
+            )
+            .await;
 
         conversation
     }
@@ -164,7 +167,7 @@ impl<'a> Conversations<'a> {
     /// - `start_date` - When the Conversation started, ISO8601 format e.g. `YYYY-MM-DDT00:00:00Z`.
     /// - `end_date` - When the Conversation ended, ISO8601 format e.g. `YYYY-MM-DDT00:00:00Z`.
     /// - `state` - Filter by state.
-    pub fn list(
+    pub async fn list(
         &self,
         start_date: Option<chrono::NaiveDate>,
         end_date: Option<chrono::NaiveDate>,
@@ -184,22 +187,28 @@ impl<'a> Conversations<'a> {
             state,
         };
 
-        let mut conversations_page = self.client.send_request::<ConversationPage, ListParams>(
-            Method::GET,
-            "https://conversations.twilio.com/v1/Conversations",
-            Some(&params),
-            None,
-        )?;
+        let mut conversations_page = self
+            .client
+            .send_request::<ConversationPage, ListParams>(
+                Method::GET,
+                "https://conversations.twilio.com/v1/Conversations",
+                Some(&params),
+                None,
+            )
+            .await?;
 
         let mut results: Vec<Conversation> = conversations_page.conversations;
 
         while (conversations_page.meta.next_page_url).is_some() {
-            conversations_page = self.client.send_request::<ConversationPage, ()>(
-                Method::GET,
-                &conversations_page.meta.next_page_url.unwrap(),
-                None,
-                None,
-            )?;
+            conversations_page = self
+                .client
+                .send_request::<ConversationPage, ()>(
+                    Method::GET,
+                    &conversations_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
 
             results.append(&mut conversations_page.conversations);
         }
@@ -211,7 +220,7 @@ impl<'a> Conversations<'a> {
     ///
     /// Takes in a `sid` argument which can also be the conversations `uniqueName` and updates the resource with the
     /// provided properties.
-    pub fn update(
+    pub async fn update(
         &self,
         sid: &str,
         updates: UpdateConversation,
@@ -223,7 +232,8 @@ impl<'a> Conversations<'a> {
                 &format!("https://conversations.twilio.com/v1/Conversations/{}", sid),
                 Some(&updates),
                 None,
-            );
+            )
+            .await;
 
         conversation
     }
@@ -231,13 +241,16 @@ impl<'a> Conversations<'a> {
     /// [Deletes a Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource#delete-a-conversation-resource)
     ///
     /// Takes in a `sid` argument which can also be the conversations `uniqueName` and **deletes** the resource.
-    pub fn delete(&self, sid: &str) -> Result<(), TwilioError> {
-        let conversation = self.client.send_request_and_ignore_response::<()>(
-            Method::DELETE,
-            &format!("https://conversations.twilio.com/v1/Conversations/{}", sid),
-            None,
-            None,
-        );
+    pub async fn delete(&self, sid: &str) -> Result<(), TwilioError> {
+        let conversation = self
+            .client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!("https://conversations.twilio.com/v1/Conversations/{}", sid),
+                None,
+                None,
+            )
+            .await;
 
         conversation
     }

--- a/twilly/src/lib.rs
+++ b/twilly/src/lib.rs
@@ -1,10 +1,11 @@
-/*! This crate is an *synchronous* implementation of the Twilio API in Rust built
+/*! This crate is an implementation of the Twilio API in Rust built
 upon Reqwest and Serde.
 
 Coverage is partial yet provides an idiomatic usage pattern currently covering:
 
 - Accounts
 - Conversations
+- Sync (Documents, Lists, and Maps)
 
 This crate has been developed alongside the `twilly-cli crate which provides an
 enhanced Twilio CLI experience.

--- a/twilly/src/lib.rs
+++ b/twilly/src/lib.rs
@@ -40,7 +40,7 @@ use std::fmt::{self};
 
 use account::Accounts;
 use conversation::Conversations;
-use reqwest::{blocking::Response, header::HeaderMap, Method};
+use reqwest::{header::HeaderMap, Method, Response};
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter, EnumString};
 use sync::Sync;
@@ -84,7 +84,7 @@ impl TwilioConfig {
 /// Twilio's API.
 pub struct Client {
     pub config: TwilioConfig,
-    client: reqwest::blocking::Client,
+    client: reqwest::Client,
 }
 
 /// Crate error wrapping containing a `kind` used
@@ -177,14 +177,14 @@ impl Client {
     pub fn new(config: &TwilioConfig) -> Self {
         Self {
             config: config.clone(),
-            client: reqwest::blocking::Client::new(),
+            client: reqwest::Client::new(),
         }
     }
 
     /// Dispatches a request to Twilio and handles parsing the response.
     ///
     /// The function takes two generics `T` and `U`. `T` is the expected response
-    /// body and `U` is the parameters structre.
+    /// body and `U` is the parameters structure.
     ///
     /// If the method allows for a request body then `params` is sent as
     /// x-www-form-urlencoded otherwise `params` are attached as query
@@ -192,7 +192,7 @@ impl Client {
     ///
     /// Will return a result of either the resource type or one of the
     /// possible errors.
-    fn send_request<T, U>(
+    async fn send_request<T, U>(
         &self,
         method: Method,
         url: &str,
@@ -203,16 +203,16 @@ impl Client {
         T: serde::de::DeserializeOwned,
         U: Serialize + ?Sized,
     {
-        let response = self.send_http_request(method, url, params, headers)?;
+        let response = self.send_http_request(method, url, params, headers).await?;
 
         match response.status().is_success() {
-            true => response.json::<T>().map_err(|error| TwilioError {
+            true => response.json::<T>().await.map_err(|error| TwilioError {
                 kind: ErrorKind::ParsingError(error),
             }),
             false => {
                 let parsed_twilio_error = response.json::<TwilioApiError>();
 
-                match parsed_twilio_error {
+                match parsed_twilio_error.await {
                     Ok(twilio_error) => Err(TwilioError {
                         kind: ErrorKind::TwilioError(twilio_error),
                     }),
@@ -228,7 +228,7 @@ impl Client {
     /// for mutating where either the response is irrelevant or there is nothing returned.
     ///
     /// Params and result follow the same behaviour as `send_request`.
-    fn send_request_and_ignore_response<T>(
+    async fn send_request_and_ignore_response<T>(
         &self,
         method: Method,
         url: &str,
@@ -238,14 +238,14 @@ impl Client {
     where
         T: Serialize + ?Sized,
     {
-        let response = self.send_http_request(method, url, params, headers)?;
+        let response = self.send_http_request(method, url, params, headers).await?;
 
         match response.status().is_success() {
             true => Ok(()),
             false => {
                 let parsed_twilio_error = response.json::<TwilioApiError>();
 
-                match parsed_twilio_error {
+                match parsed_twilio_error.await {
                     Ok(twilio_error) => Err(TwilioError {
                         kind: ErrorKind::TwilioError(twilio_error),
                     }),
@@ -259,7 +259,7 @@ impl Client {
 
     // @INTERNAL
     // Helper function for `send_request`. Not designed to be used independently.
-    fn send_http_request<T>(
+    async fn send_http_request<T>(
         &self,
         method: Method,
         url: &str,
@@ -270,20 +270,24 @@ impl Client {
         T: Serialize + ?Sized,
     {
         match method {
-            Method::GET => self
-                .client
-                .request(method, url)
-                .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
-                .headers(headers.unwrap_or_default())
-                .query(&params)
-                .send(),
-            _ => self
-                .client
-                .request(method, url)
-                .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
-                .headers(headers.unwrap_or_default())
-                .form(&params)
-                .send(),
+            Method::GET => {
+                self.client
+                    .request(method, url)
+                    .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
+                    .headers(headers.unwrap_or_default())
+                    .query(&params)
+                    .send()
+                    .await
+            }
+            _ => {
+                self.client
+                    .request(method, url)
+                    .basic_auth(&self.config.account_sid, Some(&self.config.auth_token))
+                    .headers(headers.unwrap_or_default())
+                    .form(&params)
+                    .send()
+                    .await
+            }
         }
         .map_err(|error| TwilioError {
             kind: ErrorKind::NetworkError(error),

--- a/twilly/src/sync/documents.rs
+++ b/twilly/src/sync/documents.rs
@@ -83,16 +83,19 @@ impl<'a, 'b> Documents<'a, 'b> {
     /// [Creates a Sync Document](https://www.twilio.com/docs/sync/api/document-resource)
     ///
     /// Creates a Sync Document with the provided parameters.
-    pub fn create(&self, params: CreateParams) -> Result<SyncDocument, TwilioError> {
-        let document = self.client.send_request::<SyncDocument, CreateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Documents",
-                self.service_sid
-            ),
-            Some(&params),
-            None,
-        );
+    pub async fn create(&self, params: CreateParams) -> Result<SyncDocument, TwilioError> {
+        let document = self
+            .client
+            .send_request::<SyncDocument, CreateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents",
+                    self.service_sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await;
 
         document
     }
@@ -102,26 +105,32 @@ impl<'a, 'b> Documents<'a, 'b> {
     /// Lists Sync Documents in the Sync Service provided to the `service()`.
     ///
     /// Documents will be _eagerly_ paged until all retrieved.
-    pub fn list(&self) -> Result<Vec<SyncDocument>, TwilioError> {
-        let mut documents_page = self.client.send_request::<DocumentPage, ()>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Documents?PageSize=50",
-                self.service_sid
-            ),
-            None,
-            None,
-        )?;
+    pub async fn list(&self) -> Result<Vec<SyncDocument>, TwilioError> {
+        let mut documents_page = self
+            .client
+            .send_request::<DocumentPage, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents?PageSize=50",
+                    self.service_sid
+                ),
+                None,
+                None,
+            )
+            .await?;
 
         let mut results: Vec<SyncDocument> = documents_page.documents;
 
         while (documents_page.meta.next_page_url).is_some() {
-            documents_page = self.client.send_request::<DocumentPage, ()>(
-                Method::GET,
-                &documents_page.meta.next_page_url.unwrap(),
-                None,
-                None,
-            )?;
+            documents_page = self
+                .client
+                .send_request::<DocumentPage, ()>(
+                    Method::GET,
+                    &documents_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
 
             results.append(&mut documents_page.documents);
         }
@@ -142,16 +151,19 @@ impl<'a, 'b> Document<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument and fetches the Document
     /// provided to the `document()` argument.
-    pub fn get(&self) -> Result<SyncDocument, TwilioError> {
-        let document = self.client.send_request::<SyncDocument, ()>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Documents/{}",
-                self.service_sid, self.sid
-            ),
-            None,
-            None,
-        );
+    pub async fn get(&self) -> Result<SyncDocument, TwilioError> {
+        let document = self
+            .client
+            .send_request::<SyncDocument, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents/{}",
+                    self.service_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await;
 
         document
     }
@@ -160,22 +172,25 @@ impl<'a, 'b> Document<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument and updates the Document
     /// provided to the `document()` argument.
-    pub fn update(&self, params: UpdateParams) -> Result<SyncDocument, TwilioError> {
+    pub async fn update(&self, params: UpdateParams) -> Result<SyncDocument, TwilioError> {
         let mut headers = HeaderMap::new();
 
         if let Some(if_match) = params.if_match.clone() {
             headers.append("If-Match", if_match.parse().unwrap());
         }
 
-        let document = self.client.send_request::<SyncDocument, UpdateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Documents/{}",
-                self.service_sid, self.sid
-            ),
-            Some(&params),
-            Some(headers),
-        );
+        let document = self
+            .client
+            .send_request::<SyncDocument, UpdateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents/{}",
+                    self.service_sid, self.sid
+                ),
+                Some(&params),
+                Some(headers),
+            )
+            .await;
 
         document
     }
@@ -184,16 +199,19 @@ impl<'a, 'b> Document<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument and deletes the Document
     /// provided to the `document()` argument.
-    pub fn delete(&self) -> Result<(), TwilioError> {
-        let service = self.client.send_request_and_ignore_response::<()>(
-            Method::DELETE,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Documents/{}",
-                self.service_sid, self.sid
-            ),
-            None,
-            None,
-        );
+    pub async fn delete(&self) -> Result<(), TwilioError> {
+        let service = self
+            .client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents/{}",
+                    self.service_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await;
 
         service
     }

--- a/twilly/src/sync/listitems.rs
+++ b/twilly/src/sync/listitems.rs
@@ -98,16 +98,19 @@ impl<'a, 'b> ListItems<'a, 'b> {
     /// [Creates a Sync List Item](https://www.twilio.com/docs/sync/api/listitem-resource#create-a-listitem-resource)
     ///
     /// Creates a Sync List Item with the provided parameters.
-    pub fn create(&self, params: CreateParams) -> Result<SyncListItem, TwilioError> {
-        let list_item = self.client.send_request::<SyncListItem, CreateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items",
-                self.service_sid, self.list_sid
-            ),
-            Some(&params),
-            None,
-        );
+    pub async fn create(&self, params: CreateParams) -> Result<SyncListItem, TwilioError> {
+        let list_item = self
+            .client
+            .send_request::<SyncListItem, CreateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items",
+                    self.service_sid, self.list_sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await;
 
         list_item
     }
@@ -120,26 +123,32 @@ impl<'a, 'b> ListItems<'a, 'b> {
     /// argument and lists all List items.
     ///
     /// List items will be _eagerly_ paged until all retrieved.
-    pub fn list(&self, params: ListParams) -> Result<Vec<SyncListItem>, TwilioError> {
-        let mut list_items_page = self.client.send_request::<ListItemPage, ListParams>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items?PageSize=50",
-                self.service_sid, self.list_sid
-            ),
-            Some(&params),
-            None,
-        )?;
+    pub async fn list(&self, params: ListParams) -> Result<Vec<SyncListItem>, TwilioError> {
+        let mut list_items_page = self
+            .client
+            .send_request::<ListItemPage, ListParams>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items?PageSize=50",
+                    self.service_sid, self.list_sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await?;
 
         let mut results: Vec<SyncListItem> = list_items_page.items;
 
         while (list_items_page.meta.next_page_url).is_some() {
-            list_items_page = self.client.send_request::<ListItemPage, ListParams>(
-                Method::GET,
-                &list_items_page.meta.next_page_url.unwrap(),
-                None,
-                None,
-            )?;
+            list_items_page = self
+                .client
+                .send_request::<ListItemPage, ListParams>(
+                    Method::GET,
+                    &list_items_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
 
             results.append(&mut list_items_page.items);
         }
@@ -161,16 +170,19 @@ impl<'a, 'b> ListItem<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`
     /// argument and fetches the item with the index provided to `listitem()`.
-    pub fn get(&self) -> Result<SyncListItem, TwilioError> {
-        let list_item = self.client.send_request::<SyncListItem, ()>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
-                self.service_sid, self.list_sid, self.index
-            ),
-            None,
-            None,
-        );
+    pub async fn get(&self) -> Result<SyncListItem, TwilioError> {
+        let list_item = self
+            .client
+            .send_request::<SyncListItem, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
+                    self.service_sid, self.list_sid, self.index
+                ),
+                None,
+                None,
+            )
+            .await;
 
         list_item
     }
@@ -179,22 +191,25 @@ impl<'a, 'b> ListItem<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`
     /// argument and updates the item with the index provided to `listitem()` with the parameters.
-    pub fn update(&self, params: UpdateParams) -> Result<SyncListItem, TwilioError> {
+    pub async fn update(&self, params: UpdateParams) -> Result<SyncListItem, TwilioError> {
         let mut headers = HeaderMap::new();
 
         if let Some(if_match) = params.if_match.clone() {
             headers.append("If-Match", if_match.parse().unwrap());
         }
 
-        let list_item = self.client.send_request::<SyncListItem, UpdateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
-                self.service_sid, self.list_sid, self.index
-            ),
-            Some(&params),
-            Some(headers),
-        );
+        let list_item = self
+            .client
+            .send_request::<SyncListItem, UpdateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
+                    self.service_sid, self.list_sid, self.index
+                ),
+                Some(&params),
+                Some(headers),
+            )
+            .await;
 
         list_item
     }
@@ -203,16 +218,19 @@ impl<'a, 'b> ListItem<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`
     /// argument and deletes the item with the index provided to `listitem()`.
-    pub fn delete(&self) -> Result<(), TwilioError> {
-        let list_item = self.client.send_request_and_ignore_response::<()>(
-            Method::DELETE,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
-                self.service_sid, self.list_sid, self.index
-            ),
-            None,
-            None,
-        );
+    pub async fn delete(&self) -> Result<(), TwilioError> {
+        let list_item = self
+            .client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists/{}/Items/{}",
+                    self.service_sid, self.list_sid, self.index
+                ),
+                None,
+                None,
+            )
+            .await;
 
         list_item
     }

--- a/twilly/src/sync/lists.rs
+++ b/twilly/src/sync/lists.rs
@@ -79,16 +79,19 @@ impl<'a, 'b> Lists<'a, 'b> {
     /// [Creates a Sync List resource](https://www.twilio.com/docs/sync/api/list-resource#create-a-list-resource)
     ///
     /// Creates a Sync List resource with the provided parameters.
-    pub fn create(&self, params: CreateParams) -> Result<SyncList, TwilioError> {
-        let list = self.client.send_request::<SyncList, CreateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists",
-                &self.service_sid
-            ),
-            Some(&params),
-            None,
-        );
+    pub async fn create(&self, params: CreateParams) -> Result<SyncList, TwilioError> {
+        let list = self
+            .client
+            .send_request::<SyncList, CreateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists",
+                    &self.service_sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await;
 
         list
     }
@@ -98,26 +101,32 @@ impl<'a, 'b> Lists<'a, 'b> {
     /// Lists Sync Lists existing on the Twilio account.
     ///
     /// Lists will be _eagerly_ paged until all retrieved.
-    pub fn list(&self) -> Result<Vec<SyncList>, TwilioError> {
-        let mut lists_page = self.client.send_request::<SyncListPage, ()>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists?PageSize=50",
-                self.service_sid
-            ),
-            None,
-            None,
-        )?;
+    pub async fn list(&self) -> Result<Vec<SyncList>, TwilioError> {
+        let mut lists_page = self
+            .client
+            .send_request::<SyncListPage, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists?PageSize=50",
+                    self.service_sid
+                ),
+                None,
+                None,
+            )
+            .await?;
 
         let mut results: Vec<SyncList> = lists_page.lists;
 
         while (lists_page.meta.next_page_url).is_some() {
-            lists_page = self.client.send_request::<SyncListPage, ()>(
-                Method::GET,
-                &lists_page.meta.next_page_url.unwrap(),
-                None,
-                None,
-            )?;
+            lists_page = self
+                .client
+                .send_request::<SyncListPage, ()>(
+                    Method::GET,
+                    &lists_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
 
             results.append(&mut lists_page.lists);
         }
@@ -138,16 +147,19 @@ impl<'a, 'b> List<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument and fetches the List
     /// provided to the `list()` argument.
-    pub fn get(&self) -> Result<SyncList, TwilioError> {
-        let list = self.client.send_request::<SyncList, ()>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists/{}",
-                self.service_sid, self.sid
-            ),
-            None,
-            None,
-        );
+    pub async fn get(&self) -> Result<SyncList, TwilioError> {
+        let list = self
+            .client
+            .send_request::<SyncList, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists/{}",
+                    self.service_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await;
 
         list
     }
@@ -156,16 +168,19 @@ impl<'a, 'b> List<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument  and updates the List
     /// provided to the `list()` argument.
-    pub fn update(&self, params: UpdateParams) -> Result<SyncList, TwilioError> {
-        let list = self.client.send_request::<SyncList, UpdateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists/{}",
-                self.service_sid, self.sid
-            ),
-            Some(&params),
-            None,
-        );
+    pub async fn update(&self, params: UpdateParams) -> Result<SyncList, TwilioError> {
+        let list = self
+            .client
+            .send_request::<SyncList, UpdateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists/{}",
+                    self.service_sid, self.sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await;
 
         list
     }
@@ -176,16 +191,19 @@ impl<'a, 'b> List<'a, 'b> {
     /// provided to the `list()` argument.
     ///
     /// This will delete any Sync List items underneath this list.
-    pub fn delete(&self) -> Result<(), TwilioError> {
-        let list = self.client.send_request_and_ignore_response::<()>(
-            Method::DELETE,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Lists/{}",
-                self.service_sid, self.sid
-            ),
-            None,
-            None,
-        );
+    pub async fn delete(&self) -> Result<(), TwilioError> {
+        let list = self
+            .client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Lists/{}",
+                    self.service_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await;
 
         list
     }

--- a/twilly/src/sync/mapitems.rs
+++ b/twilly/src/sync/mapitems.rs
@@ -99,16 +99,19 @@ impl<'a, 'b> MapItems<'a, 'b> {
     /// [Creates a Sync Map Item](https://www.twilio.com/docs/sync/api/map-item-resource#create-a-mapitem-resource)
     ///
     /// Creates a Sync Map Item with the provided parameters.
-    pub fn create(&self, params: CreateParams) -> Result<SyncMapItem, TwilioError> {
-        let map_item = self.client.send_request::<SyncMapItem, CreateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items",
-                self.service_sid, self.map_sid
-            ),
-            Some(&params),
-            None,
-        );
+    pub async fn create(&self, params: CreateParams) -> Result<SyncMapItem, TwilioError> {
+        let map_item = self
+            .client
+            .send_request::<SyncMapItem, CreateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items",
+                    self.service_sid, self.map_sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await;
 
         map_item
     }
@@ -121,26 +124,32 @@ impl<'a, 'b> MapItems<'a, 'b> {
     /// argument and lists all Map items.
     ///
     /// Map items will be _eagerly_ paged until all retrieved.
-    pub fn list(&self, params: ListParams) -> Result<Vec<SyncMapItem>, TwilioError> {
-        let mut map_items_page = self.client.send_request::<MapItemPage, ListParams>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items?PageSize=50",
-                self.service_sid, self.map_sid
-            ),
-            Some(&params),
-            None,
-        )?;
+    pub async fn list(&self, params: ListParams) -> Result<Vec<SyncMapItem>, TwilioError> {
+        let mut map_items_page = self
+            .client
+            .send_request::<MapItemPage, ListParams>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items?PageSize=50",
+                    self.service_sid, self.map_sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await?;
 
         let mut results: Vec<SyncMapItem> = map_items_page.items;
 
         while (map_items_page.meta.next_page_url).is_some() {
-            map_items_page = self.client.send_request::<MapItemPage, ListParams>(
-                Method::GET,
-                &map_items_page.meta.next_page_url.unwrap(),
-                None,
-                None,
-            )?;
+            map_items_page = self
+                .client
+                .send_request::<MapItemPage, ListParams>(
+                    Method::GET,
+                    &map_items_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
 
             results.append(&mut map_items_page.items);
         }
@@ -162,16 +171,19 @@ impl<'a, 'b> MapItem<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument, the Map provided to the `map()`
     /// argument and fetches the item with the key provided to `mapitem()`.
-    pub fn get(&self) -> Result<SyncMapItem, TwilioError> {
-        let map_item = self.client.send_request::<SyncMapItem, ()>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items/{}",
-                self.service_sid, self.map_sid, self.key
-            ),
-            None,
-            None,
-        );
+    pub async fn get(&self) -> Result<SyncMapItem, TwilioError> {
+        let map_item = self
+            .client
+            .send_request::<SyncMapItem, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items/{}",
+                    self.service_sid, self.map_sid, self.key
+                ),
+                None,
+                None,
+            )
+            .await;
 
         map_item
     }
@@ -180,22 +192,25 @@ impl<'a, 'b> MapItem<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument, the Map provided to the `map()`
     /// argument and updates the item with the key provided to `mapitem()` with the parameters.
-    pub fn update(&self, params: UpdateParams) -> Result<SyncMapItem, TwilioError> {
+    pub async fn update(&self, params: UpdateParams) -> Result<SyncMapItem, TwilioError> {
         let mut headers = HeaderMap::new();
 
         if let Some(if_match) = params.if_match.clone() {
             headers.append("If-Match", if_match.parse().unwrap());
         }
 
-        let map_item = self.client.send_request::<SyncMapItem, UpdateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items/{}",
-                self.service_sid, self.map_sid, self.key
-            ),
-            Some(&params),
-            Some(headers),
-        );
+        let map_item = self
+            .client
+            .send_request::<SyncMapItem, UpdateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items/{}",
+                    self.service_sid, self.map_sid, self.key
+                ),
+                Some(&params),
+                Some(headers),
+            )
+            .await;
 
         map_item
     }
@@ -204,16 +219,19 @@ impl<'a, 'b> MapItem<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument, the Map provided to the `map()`
     /// argument and deletes the item with the key provided to `mapitem()`.
-    pub fn delete(&self) -> Result<(), TwilioError> {
-        let map_item = self.client.send_request_and_ignore_response::<()>(
-            Method::DELETE,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items/{}",
-                self.service_sid, self.map_sid, self.key
-            ),
-            None,
-            None,
-        );
+    pub async fn delete(&self) -> Result<(), TwilioError> {
+        let map_item = self
+            .client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps/{}/Items/{}",
+                    self.service_sid, self.map_sid, self.key
+                ),
+                None,
+                None,
+            )
+            .await;
 
         map_item
     }

--- a/twilly/src/sync/maps.rs
+++ b/twilly/src/sync/maps.rs
@@ -79,16 +79,19 @@ impl<'a, 'b> Maps<'a, 'b> {
     /// [Creates a Sync Map resource](https://www.twilio.com/docs/sync/api/map-resource#create-a-syncmap-resource)
     ///
     /// Creates a Sync Map resource with the provided parameters.
-    pub fn create(&self, params: CreateParams) -> Result<SyncMap, TwilioError> {
-        let map = self.client.send_request::<SyncMap, CreateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps",
-                &self.service_sid
-            ),
-            Some(&params),
-            None,
-        );
+    pub async fn create(&self, params: CreateParams) -> Result<SyncMap, TwilioError> {
+        let map = self
+            .client
+            .send_request::<SyncMap, CreateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps",
+                    &self.service_sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await;
 
         map
     }
@@ -98,26 +101,32 @@ impl<'a, 'b> Maps<'a, 'b> {
     /// Lists Sync Maps existing on the Twilio account.
     ///
     /// Maps will be _eagerly_ paged until all retrieved.
-    pub fn list(&self) -> Result<Vec<SyncMap>, TwilioError> {
-        let mut maps_page = self.client.send_request::<SyncMapPage, ()>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps?PageSize=20",
-                self.service_sid
-            ),
-            None,
-            None,
-        )?;
+    pub async fn list(&self) -> Result<Vec<SyncMap>, TwilioError> {
+        let mut maps_page = self
+            .client
+            .send_request::<SyncMapPage, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps?PageSize=20",
+                    self.service_sid
+                ),
+                None,
+                None,
+            )
+            .await?;
 
         let mut results: Vec<SyncMap> = maps_page.maps;
 
         while (maps_page.meta.next_page_url).is_some() {
-            maps_page = self.client.send_request::<SyncMapPage, ()>(
-                Method::GET,
-                &maps_page.meta.next_page_url.unwrap(),
-                None,
-                None,
-            )?;
+            maps_page = self
+                .client
+                .send_request::<SyncMapPage, ()>(
+                    Method::GET,
+                    &maps_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
 
             results.append(&mut maps_page.maps);
         }
@@ -138,16 +147,19 @@ impl<'a, 'b> Map<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument and fetches the Map
     /// provided to the `map()` argument.
-    pub fn get(&self) -> Result<SyncMap, TwilioError> {
-        let map = self.client.send_request::<SyncMap, ()>(
-            Method::GET,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}",
-                self.service_sid, self.sid
-            ),
-            None,
-            None,
-        );
+    pub async fn get(&self) -> Result<SyncMap, TwilioError> {
+        let map = self
+            .client
+            .send_request::<SyncMap, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps/{}",
+                    self.service_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await;
 
         map
     }
@@ -156,16 +168,19 @@ impl<'a, 'b> Map<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `service()` argument  and updates the Map
     /// provided to the `map()` argument.
-    pub fn update(&self, params: UpdateParams) -> Result<SyncMap, TwilioError> {
-        let map = self.client.send_request::<SyncMap, UpdateParams>(
-            Method::POST,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}",
-                self.service_sid, self.sid
-            ),
-            Some(&params),
-            None,
-        );
+    pub async fn update(&self, params: UpdateParams) -> Result<SyncMap, TwilioError> {
+        let map = self
+            .client
+            .send_request::<SyncMap, UpdateParams>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps/{}",
+                    self.service_sid, self.sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await;
 
         map
     }
@@ -176,16 +191,19 @@ impl<'a, 'b> Map<'a, 'b> {
     /// provided to the `map()` argument.
     ///
     /// This will delete any Sync Map items underneath this map.
-    pub fn delete(&self) -> Result<(), TwilioError> {
-        let map = self.client.send_request_and_ignore_response::<()>(
-            Method::DELETE,
-            &format!(
-                "https://sync.twilio.com/v1/Services/{}/Maps/{}",
-                self.service_sid, self.sid
-            ),
-            None,
-            None,
-        );
+    pub async fn delete(&self) -> Result<(), TwilioError> {
+        let map = self
+            .client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Maps/{}",
+                    self.service_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await;
 
         map
     }

--- a/twilly/src/sync/services.rs
+++ b/twilly/src/sync/services.rs
@@ -91,7 +91,7 @@ impl<'a> Services<'a> {
     /// [Creates a Sync Service](https://www.twilio.com/docs/sync/api/service#create-a-service-resource)
     ///
     /// Creates a Sync Service resource with the provided parameters.
-    pub fn create(&self, params: CreateOrUpdateParams) -> Result<SyncService, TwilioError> {
+    pub async fn create(&self, params: CreateOrUpdateParams) -> Result<SyncService, TwilioError> {
         if let Some(reachability_debouncing_window) = params.reachability_debouncing_window {
             let validation =
                 validate_reachability_debouncing_window(reachability_debouncing_window);
@@ -108,7 +108,8 @@ impl<'a> Services<'a> {
                 "https://sync.twilio.com/v1/Services",
                 Some(&params),
                 None,
-            );
+            )
+            .await;
 
         service
     }
@@ -118,23 +119,29 @@ impl<'a> Services<'a> {
     /// List Sync Services existing on the Twilio account.
     ///
     /// Services will be _eagerly_ paged until all retrieved.
-    pub fn list(&self) -> Result<Vec<SyncService>, TwilioError> {
-        let mut services_page = self.client.send_request::<SyncServicePage, ()>(
-            Method::GET,
-            "https://sync.twilio.com/v1/Services?PageSize=20",
-            None,
-            None,
-        )?;
+    pub async fn list(&self) -> Result<Vec<SyncService>, TwilioError> {
+        let mut services_page = self
+            .client
+            .send_request::<SyncServicePage, ()>(
+                Method::GET,
+                "https://sync.twilio.com/v1/Services?PageSize=20",
+                None,
+                None,
+            )
+            .await?;
 
         let mut results: Vec<SyncService> = services_page.services;
 
         while (services_page.meta.next_page_url).is_some() {
-            services_page = self.client.send_request::<SyncServicePage, ()>(
-                Method::GET,
-                &services_page.meta.next_page_url.unwrap(),
-                None,
-                None,
-            )?;
+            services_page = self
+                .client
+                .send_request::<SyncServicePage, ()>(
+                    Method::GET,
+                    &services_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
 
             results.append(&mut services_page.services);
         }
@@ -152,13 +159,16 @@ impl<'a, 'b> Service<'a, 'b> {
     /// [Gets a Sync Service](https://www.twilio.com/docs/sync/api/service#fetch-a-service-resource)
     ///
     /// Fetches the Sync Service provided to the `Service()`.
-    pub fn get(&self) -> Result<SyncService, TwilioError> {
-        let service = self.client.send_request::<SyncService, ()>(
-            Method::GET,
-            &format!("https://sync.twilio.com/v1/Services/{}", self.sid),
-            None,
-            None,
-        );
+    pub async fn get(&self) -> Result<SyncService, TwilioError> {
+        let service = self
+            .client
+            .send_request::<SyncService, ()>(
+                Method::GET,
+                &format!("https://sync.twilio.com/v1/Services/{}", self.sid),
+                None,
+                None,
+            )
+            .await;
 
         service
     }
@@ -167,7 +177,7 @@ impl<'a, 'b> Service<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `Service()` argument and updates the resource with
     /// the provided properties
-    pub fn update(&self, params: CreateOrUpdateParams) -> Result<SyncService, TwilioError> {
+    pub async fn update(&self, params: CreateOrUpdateParams) -> Result<SyncService, TwilioError> {
         if let Some(reachability_debouncing_window) = params.reachability_debouncing_window {
             let validation =
                 validate_reachability_debouncing_window(reachability_debouncing_window);
@@ -184,7 +194,8 @@ impl<'a, 'b> Service<'a, 'b> {
                 &format!("https://sync.twilio.com/v1/Services/{}", self.sid),
                 Some(&params),
                 None,
-            );
+            )
+            .await;
 
         service
     }
@@ -193,13 +204,16 @@ impl<'a, 'b> Service<'a, 'b> {
     ///
     /// Targets the Sync Service provided to the `Service()` argument and deletes the resource.
     /// **Use with caution. All sub resources (documents, maps, ...) will also be removed.**
-    pub fn delete(&self) -> Result<(), TwilioError> {
-        let service = self.client.send_request_and_ignore_response::<()>(
-            Method::DELETE,
-            &format!("https://sync.twilio.com/v1/Services/{}", self.sid),
-            None,
-            None,
-        );
+    pub async fn delete(&self) -> Result<(), TwilioError> {
+        let service = self
+            .client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!("https://sync.twilio.com/v1/Services/{}", self.sid),
+                None,
+                None,
+            )
+            .await;
 
         service
     }

--- a/twilly_cli/Cargo.toml
+++ b/twilly_cli/Cargo.toml
@@ -22,3 +22,4 @@ strum = "0.26.1"
 strum_macros = "0.26.1"
 confy = "0.6.0"
 openssl = { version = "0.10", features = ["vendored"] }
+tokio = { version = "1.37.0", features = ["macros", "time"] }

--- a/twilly_cli/Cargo.toml
+++ b/twilly_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twilly_cli"
-version = "0.0.4"
+version = "0.1.0"
 edition = "2021"
 description = "A CLI tool for interacting the Twilio API built upon the twilly crate"
 authors = ["Tristan Blackwell"]
@@ -15,7 +15,7 @@ rust-version = "1.74.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-twilly = { path = "../twilly", version = "0.0.4" }
+twilly = { path = "../twilly", version = "0.1.0" }
 inquire = { version = "0.6.2", features = ["date"] }
 chrono = "0.4.31"
 strum = "0.26.1"

--- a/twilly_cli/src/account.rs
+++ b/twilly_cli/src/account.rs
@@ -167,7 +167,8 @@ pub async fn choose_account_action(twilio: &Client) {
                                                             change_account_name(
                                                                 twilio,
                                                                 &selected_account.sid,
-                                                            );
+                                                            )
+                                                            .await;
                                                             accounts[selected_account_index
                                                                 .expect(
                                                                     "Selected account is unknown",
@@ -178,7 +179,8 @@ pub async fn choose_account_action(twilio: &Client) {
                                                             suspend_account(
                                                                 twilio,
                                                                 &selected_account.sid,
-                                                            );
+                                                            )
+                                                            .await;
                                                             accounts[selected_account_index
                                                                 .expect(
                                                                     "Selected account is unknown",
@@ -189,7 +191,8 @@ pub async fn choose_account_action(twilio: &Client) {
                                                             close_account(
                                                                 twilio,
                                                                 &selected_account.sid,
-                                                            );
+                                                            )
+                                                            .await;
                                                             accounts[selected_account_index
                                                                 .expect(
                                                                     "Selected account is unknown",
@@ -220,7 +223,8 @@ pub async fn choose_account_action(twilio: &Client) {
                                                             change_account_name(
                                                                 twilio,
                                                                 &selected_account.sid,
-                                                            );
+                                                            )
+                                                            .await;
                                                             accounts[selected_account_index
                                                                 .expect(
                                                                     "Selected account is unknown",
@@ -231,7 +235,8 @@ pub async fn choose_account_action(twilio: &Client) {
                                                             activate_account(
                                                                 twilio,
                                                                 &selected_account.sid,
-                                                            );
+                                                            )
+                                                            .await;
                                                             accounts[selected_account_index
                                                                 .expect(
                                                                     "Selected account is unknown",

--- a/twilly_cli/src/account.rs
+++ b/twilly_cli/src/account.rs
@@ -21,7 +21,7 @@ pub enum Action {
     Exit,
 }
 
-pub fn choose_account_action(twilio: &Client) {
+pub async fn choose_account_action(twilio: &Client) {
     let options: Vec<Action> = Action::iter().collect();
 
     loop {
@@ -49,6 +49,7 @@ pub fn choose_account_action(twilio: &Client) {
                         let account = twilio
                             .accounts()
                             .get(Some(&account_sid))
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         println!("{:#?}", account);
                         println!();
@@ -63,6 +64,7 @@ pub fn choose_account_action(twilio: &Client) {
                         let account = twilio
                             .accounts()
                             .create(Some(&friendly_name))
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         println!(
                             "Account created: {} ({})",
@@ -91,6 +93,7 @@ pub fn choose_account_action(twilio: &Client) {
                             let mut accounts = twilio
                                 .accounts()
                                 .list(Some(&friendly_name), status.as_ref())
+                                .await
                                 .unwrap_or_else(|error| panic!("{}", error));
 
                             // The action we can perform on the account we are using are limited.
@@ -272,7 +275,7 @@ pub fn choose_account_action(twilio: &Client) {
     }
 }
 
-fn change_account_name(twilio: &Client, account_sid: &str) {
+async fn change_account_name(twilio: &Client, account_sid: &str) {
     let friendly_name_prompt =
         Text::new("Provide a name:").with_validator(|val: &str| match val.len() > 0 {
             true => Ok(Validation::Valid),
@@ -284,6 +287,7 @@ fn change_account_name(twilio: &Client, account_sid: &str) {
         let updated_account = twilio
             .accounts()
             .update(account_sid, Some(&friendly_name), None)
+            .await
             .unwrap_or_else(|error| panic!("{}", error));
 
         println!("{:#?}", updated_account);
@@ -291,7 +295,7 @@ fn change_account_name(twilio: &Client, account_sid: &str) {
     }
 }
 
-fn activate_account(twilio: &Client, account_sid: &str) {
+async fn activate_account(twilio: &Client, account_sid: &str) {
     let confirmation_prompt =
         Confirm::new("Are you sure you wish to activate this account? (Yes / No)");
 
@@ -301,6 +305,7 @@ fn activate_account(twilio: &Client, account_sid: &str) {
             twilio
                 .accounts()
                 .update(account_sid, None, Some(&Status::Suspended))
+                .await
                 .unwrap_or_else(|error| panic!("{}", error));
 
             println!("Account activated.");
@@ -311,7 +316,7 @@ fn activate_account(twilio: &Client, account_sid: &str) {
     println!("Operation canceled. No changes were made.");
 }
 
-fn suspend_account(twilio: &Client, account_sid: &str) {
+async fn suspend_account(twilio: &Client, account_sid: &str) {
     let confirmation_prompt =
         Confirm::new("Are you sure you wish to suspend this account? Any activity will be disabled until the account is re-activated. (Yes / No)");
 
@@ -321,6 +326,7 @@ fn suspend_account(twilio: &Client, account_sid: &str) {
             let res = twilio
                 .accounts()
                 .update(account_sid, None, Some(&Status::Suspended))
+                .await
                 .unwrap_or_else(|error| panic!("{}", error));
 
             println!("{}", res);
@@ -332,7 +338,7 @@ fn suspend_account(twilio: &Client, account_sid: &str) {
     println!("Operation canceled. No changes were made.");
 }
 
-fn close_account(twilio: &Client, account_sid: &str) {
+async fn close_account(twilio: &Client, account_sid: &str) {
     let confirmation_prompt =
         Confirm::new("Are you sure you wish to Close this account? Activity will be disabled and this action cannot be reversed. (Yes / No)");
 
@@ -342,6 +348,7 @@ fn close_account(twilio: &Client, account_sid: &str) {
             twilio
                 .accounts()
                 .update(account_sid, None, Some(&Status::Suspended))
+                .await
                 .unwrap_or_else(|error| panic!("{}", error));
 
             println!(

--- a/twilly_cli/src/main.rs
+++ b/twilly_cli/src/main.rs
@@ -9,7 +9,8 @@ use strum::IntoEnumIterator;
 use twilly::{self, SubResource, TwilioConfig};
 use twilly_cli::{prompt_user_selection, request_credentials};
 
-fn main() {
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     print_welcome_message();
 
     let mut loaded_config = false;
@@ -46,6 +47,7 @@ fn main() {
         let account = twilio
             .accounts()
             .get(None)
+            .await
             .unwrap_or_else(|error| panic!("{}", error));
 
         println!(
@@ -80,9 +82,11 @@ fn main() {
         let sub_resource = SubResource::from_str(&sub_resource).unwrap();
 
         match sub_resource {
-            twilly::SubResource::Account => account::choose_account_action(&twilio),
-            twilly::SubResource::Conversations => conversation::choose_conversation_action(&twilio),
-            twilly::SubResource::Sync => sync::choose_sync_resource(&twilio),
+            twilly::SubResource::Account => account::choose_account_action(&twilio).await,
+            twilly::SubResource::Conversations => {
+                conversation::choose_conversation_action(&twilio).await
+            }
+            twilly::SubResource::Sync => sync::choose_sync_resource(&twilio).await,
         }
     }
 }

--- a/twilly_cli/src/sync.rs
+++ b/twilly_cli/src/sync.rs
@@ -27,11 +27,12 @@ pub enum Action {
     Exit,
 }
 
-pub fn choose_sync_resource(twilio: &Client) {
+pub async fn choose_sync_resource(twilio: &Client) {
     let mut sync_services = twilio
         .sync()
         .services()
         .list()
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_services.len() == 0 {
@@ -88,6 +89,7 @@ pub fn choose_sync_resource(twilio: &Client) {
                                             webhooks_from_rest_enabled: None,
                                             webhook_url: None,
                                         })
+                                        .await
                                         .unwrap_or_else(|error| panic!("{}", error));
                                     sync_services.push(sync_service);
                                     selected_sync_service_index = Some(sync_services.len() - 1);
@@ -121,10 +123,10 @@ pub fn choose_sync_resource(twilio: &Client) {
         if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
             match resource {
                 Action::Document => {
-                    documents::choose_document_action(&twilio, selected_sync_service)
+                    documents::choose_document_action(&twilio, selected_sync_service).await
                 }
-                Action::Map => maps::choose_map_action(&twilio, selected_sync_service),
-                Action::List => lists::choose_list_action(&twilio, selected_sync_service),
+                Action::Map => maps::choose_map_action(&twilio, selected_sync_service).await,
+                Action::List => lists::choose_list_action(&twilio, selected_sync_service).await,
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_service);
                     println!()
@@ -139,6 +141,7 @@ pub fn choose_sync_resource(twilio: &Client) {
                             .sync()
                             .service(&selected_sync_service.sid)
                             .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_services.remove(
                             selected_sync_service_index.expect(

--- a/twilly_cli/src/sync/documents.rs
+++ b/twilly_cli/src/sync/documents.rs
@@ -16,7 +16,7 @@ pub enum Action {
     Exit,
 }
 
-pub fn choose_document_action(twilio: &Client, sync_service: &SyncService) {
+pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService) {
     let options: Vec<Action> = Action::iter().collect();
 
     loop {
@@ -47,6 +47,7 @@ pub fn choose_document_action(twilio: &Client, sync_service: &SyncService) {
                             .service(&sync_service.sid)
                             .document(&document_sid)
                             .get()
+                            .await
                         {
                             Ok(document) => loop {
                                 if let Some(action_choice) = get_action_choice_from_user(
@@ -75,6 +76,7 @@ pub fn choose_document_action(twilio: &Client, sync_service: &SyncService) {
                                                         .service(&sync_service.sid)
                                                         .document(&document_sid)
                                                         .delete()
+                                                        .await
                                                         .unwrap_or_else(|error| {
                                                             panic!("{}", error)
                                                         });
@@ -112,6 +114,7 @@ pub fn choose_document_action(twilio: &Client, sync_service: &SyncService) {
                         .service(&sync_service.sid)
                         .documents()
                         .list()
+                        .await
                         .unwrap_or_else(|error| panic!("{}", error));
 
                     let number_of_documents = documents.len();
@@ -183,6 +186,7 @@ pub fn choose_document_action(twilio: &Client, sync_service: &SyncService) {
                                                         .service(&sync_service.sid)
                                                         .document(&selected_document.sid)
                                                         .delete()
+                                                        .await
                                                         .unwrap_or_else(|error| {
                                                             panic!("{}", error)
                                                         });

--- a/twilly_cli/src/sync/listitems.rs
+++ b/twilly_cli/src/sync/listitems.rs
@@ -18,7 +18,7 @@ pub enum Action {
     Exit,
 }
 
-pub fn choose_list_item_action(twilio: &Client, sync_service: &SyncService, list: &SyncList) {
+pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService, list: &SyncList) {
     let mut sync_list_items = twilio
         .sync()
         .service(&sync_service.sid)
@@ -29,6 +29,7 @@ pub fn choose_list_item_action(twilio: &Client, sync_service: &SyncService, list
             bounds: None,
             from: None,
         })
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_list_items.len() == 0 {
@@ -91,6 +92,7 @@ pub fn choose_list_item_action(twilio: &Client, sync_service: &SyncService, list
                             .list(&list.sid)
                             .listitem(&selected_sync_list_item.index)
                             .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_list_items.remove(selected_sync_list_index.expect(
                             "Could not find Sync List item in existing Sync List items list",

--- a/twilly_cli/src/sync/lists.rs
+++ b/twilly_cli/src/sync/lists.rs
@@ -19,12 +19,13 @@ pub enum Action {
     Exit,
 }
 
-pub fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
+pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
     let mut sync_lists = twilio
         .sync()
         .service(&sync_service.sid)
         .lists()
         .list()
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_lists.len() == 0 {
@@ -72,6 +73,7 @@ pub fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
             match resource {
                 Action::ListItem => {
                     listitems::choose_list_item_action(&twilio, sync_service, &selected_sync_list)
+                        .await
                 }
 
                 Action::ListDetails => {
@@ -89,6 +91,7 @@ pub fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
                             .service(&sync_service.sid)
                             .list(&selected_sync_list.sid)
                             .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_lists.remove(
                             selected_sync_list_index

--- a/twilly_cli/src/sync/mapitems.rs
+++ b/twilly_cli/src/sync/mapitems.rs
@@ -18,7 +18,7 @@ pub enum Action {
     Exit,
 }
 
-pub fn choose_map_item_action(twilio: &Client, sync_service: &SyncService, map: &SyncMap) {
+pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService, map: &SyncMap) {
     let mut sync_map_items = twilio
         .sync()
         .service(&sync_service.sid)
@@ -29,6 +29,7 @@ pub fn choose_map_item_action(twilio: &Client, sync_service: &SyncService, map: 
             bounds: None,
             from: None,
         })
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_map_items.len() == 0 {
@@ -91,6 +92,7 @@ pub fn choose_map_item_action(twilio: &Client, sync_service: &SyncService, map: 
                             .map(&map.sid)
                             .mapitem(&selected_sync_map_item.key)
                             .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_map_items.remove(selected_sync_map_index.expect(
                             "Could not find Sync Map item in existing Sync Map items list",

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -19,12 +19,13 @@ pub enum Action {
     Exit,
 }
 
-pub fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
+pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
     let mut sync_maps = twilio
         .sync()
         .service(&sync_service.sid)
         .maps()
         .list()
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_maps.len() == 0 {
@@ -72,6 +73,7 @@ pub fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
             match resource {
                 Action::MapItem => {
                     mapitems::choose_map_item_action(&twilio, sync_service, &selected_sync_map)
+                        .await
                 }
 
                 Action::ListDetails => {
@@ -89,6 +91,7 @@ pub fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                             .service(&sync_service.sid)
                             .map(&selected_sync_map.sid)
                             .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_maps.remove(
                             selected_sync_map_index


### PR DESCRIPTION
Adds in Tokio, replacing the blocking client from Reqwest with the non-blocking version to support async functions in `twilly`. `twilly_cli` has been updated to support the new async nature.