### PR TITLE
Fix: Sync Data Serialization

### DIFF
--- a/twilly/src/account.rs
+++ b/twilly/src/account.rs
@@ -90,16 +90,16 @@ impl Status {
 /// Possible filters when listing Accounts via the Twilio API
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
-struct ListOrUpdateParams {
-    friendly_name: Option<String>,
-    status: Option<Status>,
+pub struct ListOrUpdateParams {
+    pub friendly_name: Option<String>,
+    pub status: Option<Status>,
 }
 
 /// Possible options when creating an Account via the Twilio API
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
-struct CreateParams {
-    friendly_name: Option<String>,
+pub struct CreateParams {
+    pub friendly_name: Option<String>,
 }
 
 impl<'a> Accounts<'a> {

--- a/twilly/src/conversation.rs
+++ b/twilly/src/conversation.rs
@@ -135,10 +135,10 @@ impl Default for Links {
 /// Possible filters when listing Conversations via the Twilio API
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
-struct ListParams {
-    start_date: Option<String>,
-    end_date: Option<String>,
-    state: Option<State>,
+pub struct ListParams {
+    pub start_date: Option<String>,
+    pub end_date: Option<String>,
+    pub state: Option<State>,
 }
 
 impl<'a> Conversations<'a> {

--- a/twilly/src/sync/documents.rs
+++ b/twilly/src/sync/documents.rs
@@ -56,10 +56,10 @@ pub struct CreateParams<'a, T>
 where
     T: ?Sized + Serialize,
 {
-    unique_name: Option<String>,
-    data: &'a T,
+    pub unique_name: Option<String>,
+    pub data: &'a T,
     /// How long the Document should exist before deletion (in seconds).
-    ttl: Option<u16>,
+    pub ttl: Option<u16>,
 }
 
 /// Parameters for creating a Sync Document with
@@ -67,7 +67,7 @@ where
 #[skip_serializing_none]
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
-pub struct CreateParamsWithJson {
+struct CreateParamsWithJson {
     unique_name: Option<String>,
     data: String,
     /// How long the Document should exist before deletion (in seconds).
@@ -79,11 +79,11 @@ pub struct UpdateParams<'a, T>
 where
     T: ?Sized + Serialize,
 {
-    if_match: Option<String>,
+    pub if_match: Option<String>,
     /// Any value that can be represented as JSON
-    data: &'a T,
+    pub data: &'a T,
     /// How long the Document should exist before deletion (in seconds).
-    ttl: Option<u16>,
+    pub ttl: Option<u16>,
 }
 
 /// Parameters for creating a Sync Document with
@@ -91,7 +91,7 @@ where
 #[skip_serializing_none]
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
-pub struct UpdateParamsWithJson {
+struct UpdateParamsWithJson {
     #[serde(rename(serialize = "If-Match"))]
     if_match: Option<String>,
     /// Any value that can be represented as JSON

--- a/twilly/src/sync/listitems.rs
+++ b/twilly/src/sync/listitems.rs
@@ -41,19 +41,19 @@ pub struct CreateParams<'a, T>
 where
     T: ?Sized + Serialize,
 {
-    data: &'a T,
+    pub data: &'a T,
     /// How long the List Item should exist before deletion (in seconds).
-    ttl: Option<u16>,
+    pub ttl: Option<u16>,
     /// How long the *parent* List resource should exist before deletion (in seconds).
-    collection_ttl: Option<u16>,
+    pub collection_ttl: Option<u16>,
 }
 
-/// Parameters for creating a Sync Document with
+/// Parameters for creating a Sync List with
 /// data converted to a JSON string
 #[skip_serializing_none]
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
-pub struct CreateParamsWithJson {
+struct CreateParamsWithJson {
     data: String,
     /// How long the List Item should exist before deletion (in seconds).
     ttl: Option<u16>,
@@ -86,21 +86,21 @@ pub struct ListParams {
     pub bounds: Option<Bounds>,
 }
 
-/// Parameters for updating a Sync Map Item
+/// Parameters for updating a Sync Map List
 pub struct UpdateParams<'a, T>
 where
     T: ?Sized + Serialize,
 {
-    if_match: Option<String>,
-    data: &'a T,
-    /// How long the Map Item should exist before deletion (in seconds).
-    ttl: Option<u16>,
-    /// How long the *parent* Map resource should exist before deletion (in seconds). Can only be used
+    pub if_match: Option<String>,
+    pub data: &'a T,
+    /// How long the List Item should exist before deletion (in seconds).
+    pub ttl: Option<u16>,
+    /// How long the *parent* List resource should exist before deletion (in seconds). Can only be used
     /// if the `data` or `ttl` is updated in the same request.
-    collection_ttl: Option<u16>,
+    pub collection_ttl: Option<u16>,
 }
 
-/// Parameters for creating a Sync Document with
+/// Parameters for creating a Sync List with
 /// data converted to a JSON string
 #[skip_serializing_none]
 #[derive(Serialize)]
@@ -109,9 +109,9 @@ struct UpdateParamsWithJson {
     #[serde(rename(serialize = "If-Match"))]
     if_match: Option<String>,
     data: String,
-    /// How long the Map Item should exist before deletion (in seconds).
+    /// How long the List Item should exist before deletion (in seconds).
     ttl: Option<u16>,
-    /// How long the *parent* Map resource should exist before deletion (in seconds). Can only be used
+    /// How long the *parent* List resource should exist before deletion (in seconds). Can only be used
     /// if the `data` or `ttl` is updated in the same request.
     collection_ttl: Option<u16>,
 }

--- a/twilly/src/sync/lists.rs
+++ b/twilly/src/sync/lists.rs
@@ -58,8 +58,8 @@ impl Default for Links {
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
 pub struct CreateParams {
-    unique_name: Option<String>,
-    ttl: Option<bool>,
+    pub unique_name: Option<String>,
+    pub ttl: Option<bool>,
 }
 
 /// Parameters for updating a Sync List
@@ -67,7 +67,7 @@ pub struct CreateParams {
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
 pub struct UpdateParams {
-    ttl: Option<bool>,
+    pub ttl: Option<bool>,
 }
 
 pub struct Lists<'a, 'b> {

--- a/twilly/src/sync/mapitems.rs
+++ b/twilly/src/sync/mapitems.rs
@@ -57,14 +57,14 @@ where
 #[skip_serializing_none]
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
-pub struct CreateParamsWithJson {
-    pub key: String,
+struct CreateParamsWithJson {
+    key: String,
     /// JSON string of data
-    pub data: String,
+    data: String,
     /// How long the Map Item should exist before deletion (in seconds).
-    pub ttl: Option<u16>,
+    ttl: Option<u16>,
     /// How long the *parent* Map resource should exist before deletion (in seconds).
-    pub collection_ttl: Option<u16>,
+    collection_ttl: Option<u16>,
 }
 
 #[derive(Serialize)]
@@ -97,14 +97,14 @@ pub struct UpdateParams<'a, T>
 where
     T: ?Sized + Serialize,
 {
-    if_match: Option<String>,
+    pub if_match: Option<String>,
     /// Any value that can be represented as JSON
     pub data: &'a T,
     /// How long the Map Item should exist before deletion (in seconds).
-    ttl: Option<u16>,
+    pub ttl: Option<u16>,
     /// How long the *parent* Map resource should exist before deletion (in seconds). Can only be used
     /// if the `data` or `ttl` is updated in the same request.
-    collection_ttl: Option<u16>,
+    pub collection_ttl: Option<u16>,
 }
 
 /// Parameters for updating a Sync Map Item with
@@ -112,11 +112,11 @@ where
 #[skip_serializing_none]
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
-pub struct UpdateParamsWithJson {
+struct UpdateParamsWithJson {
     #[serde(rename(serialize = "If-Match"))]
     if_match: Option<String>,
     /// Any value that can be represented as JSON
-    pub data: String,
+    data: String,
     /// How long the Map Item should exist before deletion (in seconds).
     ttl: Option<u16>,
     /// How long the *parent* Map resource should exist before deletion (in seconds). Can only be used

--- a/twilly/src/sync/maps.rs
+++ b/twilly/src/sync/maps.rs
@@ -15,8 +15,8 @@ use super::mapitems::{MapItem, MapItems};
 #[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct SyncMapPage {
-    maps: Vec<SyncMap>,
-    meta: PageMeta,
+    pub maps: Vec<SyncMap>,
+    pub meta: PageMeta,
 }
 
 /// A Sync Map resource.
@@ -58,8 +58,8 @@ impl Default for Links {
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
 pub struct CreateParams {
-    unique_name: Option<String>,
-    ttl: Option<bool>,
+    pub unique_name: Option<String>,
+    pub ttl: Option<bool>,
 }
 
 /// Parameters for updating a Sync Map
@@ -67,7 +67,7 @@ pub struct CreateParams {
 #[derive(Serialize)]
 #[serde(rename_all(serialize = "PascalCase"))]
 pub struct UpdateParams {
-    ttl: Option<bool>,
+    pub ttl: Option<bool>,
 }
 
 pub struct Maps<'a, 'b> {

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -1,9 +1,16 @@
 use std::process;
 
-use inquire::{Confirm, Select};
+use inquire::{Confirm, Select, Text};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{sync::services::SyncService, Client};
+use twilly::{
+    sync::{
+        mapitems::{CreateParams as CreateMapItemParams, ListParams},
+        maps::CreateParams as CreateMapParams,
+        services::SyncService,
+    },
+    Client,
+};
 use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
 
 use crate::sync::mapitems;
@@ -14,6 +21,7 @@ pub enum Action {
     MapItem,
     #[strum(to_string = "List Details")]
     ListDetails,
+    Rename,
     Delete,
     Back,
     Exit,
@@ -79,6 +87,87 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_map);
                     println!()
+                }
+                Action::Rename => {
+                    let get_renamed_map_name = Text::new(
+                        "What would you like to rename this map to? The new map name must match `^[a-zA-Z-_0-9]+$`"
+                    );
+                    let get_rename_prompt_result = prompt_user(get_renamed_map_name);
+                    let mut new_name = String::from("");
+                    if get_rename_prompt_result.is_none() {
+                        println!("No name entered");
+                        break;
+                    }
+
+                    let unwrapped = get_rename_prompt_result.unwrap();
+                    new_name = unwrapped
+                        .chars()
+                        .filter(|c| {
+                            (c.is_alphabetic() || c.is_numeric() || c.eq(&'-') || c.eq(&'_'))
+                        })
+                        .collect();
+
+                    if new_name.is_empty() {
+                        println!("Name was not valid");
+                        break;
+                    }
+
+                    let message =
+                        format!("We will rename the map to {}.\nThis process will create a temporary map copy which you can delete after.\nDo you wish to continue?", new_name);
+
+                    let info_prompt = Confirm::new(&message.as_str())
+                        .with_placeholder("No")
+                        .with_default(false);
+                    let confirmation = prompt_user(info_prompt);
+                    if confirmation.is_none() || confirmation.unwrap() == false {
+                        break;
+                    }
+
+                    println!("(0/6) -> Starting map rename");
+                    println!("(1/6) -> Creating temporary duplicate map");
+                    let temp_map = twilio
+                        .sync()
+                        .service(&sync_service.sid)
+                        .maps()
+                        .create(CreateMapParams {
+                            unique_name: Some(String::from("test-temp")),
+                            ttl: None,
+                        })
+                        .await
+                        .unwrap_or_else(|error| panic!("{}", error));
+                    println!("(2/6) -> Cloning items to temporary map");
+                    let items = twilio
+                        .sync()
+                        .service(&sync_service.sid)
+                        .map(&selected_sync_map.sid)
+                        .mapitems()
+                        .list(ListParams {
+                            from: None,
+                            bounds: None,
+                            order: None,
+                        })
+                        .await
+                        .unwrap_or_else(|error| panic!("{}", error));
+                    let mut items_iter = items.into_iter();
+                    while let Some(item) = items_iter.next() {
+                        twilio
+                            .sync()
+                            .service(&sync_service.sid)
+                            .map(&temp_map.sid)
+                            .mapitems()
+                            .create(CreateMapItemParams {
+                                key: item.key,
+                                ttl: None,
+                                collection_ttl: None,
+                                data: &item.data,
+                            })
+                            .await
+                            .unwrap_or_else(|error| panic!("{}", error));
+                    }
+                    println!("(3/6) -> Deleting original map");
+                    println!("(4/6) -> Creating renamed map");
+                    println!("(5/6) -> Cloning items to renamed map");
+                    println!("(6/6) -> Done");
                 }
                 Action::Delete => {
                     let confirm_prompt =


### PR DESCRIPTION
Fixes an issue where data typed as `serde_json::Value` (generally data parameters for creating & updating Sync items) could not be serialized by reqwest into the `application/x-www-form-urlencoded` body.

These `serde_json::Value` properties are now turned into a JSON string using `serde_json::to_string` with an intermediatary struct before passing to reqwest