### PR TITLE
Feature/sensible confirm defaults

### DIFF
--- a/twilly_cli/src/account.rs
+++ b/twilly_cli/src/account.rs
@@ -1,12 +1,16 @@
-use std::{process, str::FromStr};
+use std::{ process, str::FromStr };
 
-use inquire::{validator::Validation, Confirm, Select, Text};
+use inquire::{ validator::Validation, Confirm, Select, Text };
 use strum::IntoEnumIterator;
-use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{account::Status, Client};
+use strum_macros::{ Display, EnumIter, EnumString };
+use twilly::{ account::Status, Client };
 use twilly_cli::{
-    get_action_choice_from_user, get_filter_choice_from_user, prompt_user, prompt_user_selection,
-    ActionChoice, FilterChoice,
+    get_action_choice_from_user,
+    get_filter_choice_from_user,
+    prompt_user,
+    prompt_user_selection,
+    ActionChoice,
+    FilterChoice,
 };
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
@@ -32,68 +36,77 @@ pub async fn choose_account_action(twilio: &Client) {
                 Action::GetAccount => {
                     let account_sid_prompt = Text::new("Please provide an account SID:")
                         .with_placeholder("AC...")
-                        .with_validator(|val: &str| match val.starts_with("AC") {
-                            true => Ok(Validation::Valid),
-                            false => {
-                                Ok(Validation::Invalid("Account SID must start with AC".into()))
+                        .with_validator(|val: &str| {
+                            match val.starts_with("AC") {
+                                true => Ok(Validation::Valid),
+                                false => {
+                                    Ok(Validation::Invalid("Account SID must start with AC".into()))
+                                }
                             }
                         })
-                        .with_validator(|val: &str| match val.len() {
-                            34 => Ok(Validation::Valid),
-                            _ => Ok(Validation::Invalid(
-                                "Your SID should be 34 characters in length".into(),
-                            )),
+                        .with_validator(|val: &str| {
+                            match val.len() {
+                                34 => Ok(Validation::Valid),
+                                _ =>
+                                    Ok(
+                                        Validation::Invalid(
+                                            "Your SID should be 34 characters in length".into()
+                                        )
+                                    ),
+                            }
                         });
 
                     if let Some(account_sid) = prompt_user(account_sid_prompt) {
                         let account = twilio
                             .accounts()
-                            .get(Some(&account_sid))
-                            .await
+                            .get(Some(&account_sid)).await
                             .unwrap_or_else(|error| panic!("{}", error));
                         println!("{:#?}", account);
                         println!();
                     }
                 }
                 Action::CreateAccount => {
-                    let friendly_name_prompt =
-                        Text::new("Enter a friendly name (empty for default):");
+                    let friendly_name_prompt = Text::new(
+                        "Enter a friendly name (empty for default):"
+                    );
 
                     if let Some(friendly_name) = prompt_user(friendly_name_prompt) {
                         println!("Creating account...");
                         let account = twilio
                             .accounts()
-                            .create(Some(&friendly_name))
-                            .await
+                            .create(Some(&friendly_name)).await
                             .unwrap_or_else(|error| panic!("{}", error));
-                        println!(
-                            "Account created: {} ({})",
-                            account.friendly_name, account.sid
-                        );
+                        println!("Account created: {} ({})", account.friendly_name, account.sid);
                     }
                 }
                 Action::ListAccounts => {
-                    let friendly_name_prompt =
-                        Text::new("Search by friendly name? (empty for none):");
+                    let friendly_name_prompt = Text::new(
+                        "Search by friendly name? (empty for none):"
+                    );
 
                     if let Some(friendly_name) = prompt_user(friendly_name_prompt) {
-                        if let Some(filter_choice) = get_filter_choice_from_user(
-                            Status::iter().map(|status| status.to_string()).collect(),
-                            "Filter by status: ",
-                        ) {
+                        if
+                            let Some(filter_choice) = get_filter_choice_from_user(
+                                Status::iter()
+                                    .map(|status| status.to_string())
+                                    .collect(),
+                                "Filter by status: "
+                            )
+                        {
                             let status = match filter_choice {
                                 FilterChoice::Any => None,
-                                FilterChoice::Other(choice) => Some(
-                                    Status::from_str(&choice)
-                                        .expect("Unable to determine account status"),
-                                ),
+                                FilterChoice::Other(choice) =>
+                                    Some(
+                                        Status::from_str(&choice).expect(
+                                            "Unable to determine account status"
+                                        )
+                                    ),
                             };
 
                             println!("Retrieving accounts...");
                             let mut accounts = twilio
                                 .accounts()
-                                .list(Some(&friendly_name), status.as_ref())
-                                .await
+                                .list(Some(&friendly_name), status.as_ref()).await
                                 .unwrap_or_else(|error| panic!("{}", error));
 
                             // The action we can perform on the account we are using are limited.
@@ -116,18 +129,22 @@ pub async fn choose_account_action(twilio: &Client) {
                                 let selected_account = if let Some(index) = selected_account_index {
                                     &mut accounts[index]
                                 } else {
-                                    if let Some(action_choice) = get_action_choice_from_user(
-                                        accounts
-                                            .iter()
-                                            .map(|ac| {
-                                                format!(
-                                                    "({}) {} - {}",
-                                                    ac.sid, ac.friendly_name, ac.status
-                                                )
-                                            })
-                                            .collect::<Vec<String>>(),
-                                        "Accounts: ",
-                                    ) {
+                                    if
+                                        let Some(action_choice) = get_action_choice_from_user(
+                                            accounts
+                                                .iter()
+                                                .map(|ac| {
+                                                    format!(
+                                                        "({}) {} - {}",
+                                                        ac.sid,
+                                                        ac.friendly_name,
+                                                        ac.status
+                                                    )
+                                                })
+                                                .collect::<Vec<String>>(),
+                                            "Accounts: "
+                                        )
+                                    {
                                         match action_choice {
                                             ActionChoice::Back => {
                                                 break;
@@ -136,8 +153,12 @@ pub async fn choose_account_action(twilio: &Client) {
                                             ActionChoice::Other(choice) => {
                                                 let account_position = accounts
                                                     .iter()
-                                                    .position(|account| account.sid == choice[1..35])
-                                                    .expect("Could not find account in existing account list");
+                                                    .position(
+                                                        |account| account.sid == choice[1..35]
+                                                    )
+                                                    .expect(
+                                                        "Could not find account in existing account list"
+                                                    );
 
                                                 selected_account_index = Some(account_position);
                                                 &mut accounts[account_position]
@@ -150,57 +171,58 @@ pub async fn choose_account_action(twilio: &Client) {
 
                                 match selected_account.status.as_str() {
                                     "active" => {
-                                        if let Some(account_action) = get_action_choice_from_user(
-                                            vec![
-                                                "Change name".into(),
-                                                "Suspend".into(),
-                                                "Close".into(),
-                                            ],
-                                            "Select an action: ",
-                                        ) {
+                                        if
+                                            let Some(account_action) = get_action_choice_from_user(
+                                                vec![
+                                                    "Change name".into(),
+                                                    "Suspend".into(),
+                                                    "Close".into()
+                                                ],
+                                                "Select an action: "
+                                            )
+                                        {
                                             match account_action {
-                                                ActionChoice::Back => break,
+                                                ActionChoice::Back => {
+                                                    break;
+                                                }
                                                 ActionChoice::Exit => process::exit(0),
                                                 ActionChoice::Other(choice) => {
                                                     match choice.as_str() {
                                                         "Change name" => {
                                                             change_account_name(
                                                                 twilio,
-                                                                &selected_account.sid,
-                                                            )
-                                                            .await;
-                                                            accounts[selected_account_index
-                                                                .expect(
-                                                                    "Selected account is unknown",
-                                                                )]
-                                                            .friendly_name = friendly_name.clone();
+                                                                &selected_account.sid
+                                                            ).await;
+                                                            accounts[
+                                                                selected_account_index.expect(
+                                                                    "Selected account is unknown"
+                                                                )
+                                                            ].friendly_name = friendly_name.clone();
                                                         }
                                                         "Suspend" => {
                                                             suspend_account(
                                                                 twilio,
-                                                                &selected_account.sid,
-                                                            )
-                                                            .await;
-                                                            accounts[selected_account_index
-                                                                .expect(
-                                                                    "Selected account is unknown",
-                                                                )]
-                                                            .status = Status::Suspended;
+                                                                &selected_account.sid
+                                                            ).await;
+                                                            accounts[
+                                                                selected_account_index.expect(
+                                                                    "Selected account is unknown"
+                                                                )
+                                                            ].status = Status::Suspended;
                                                         }
                                                         "Close" => {
                                                             close_account(
                                                                 twilio,
-                                                                &selected_account.sid,
-                                                            )
-                                                            .await;
-                                                            accounts[selected_account_index
-                                                                .expect(
-                                                                    "Selected account is unknown",
-                                                                )]
-                                                            .status = Status::Closed;
+                                                                &selected_account.sid
+                                                            ).await;
+                                                            accounts[
+                                                                selected_account_index.expect(
+                                                                    "Selected account is unknown"
+                                                                )
+                                                            ].status = Status::Closed;
                                                         }
                                                         _ => {
-                                                            println!("Unknown action '{}'", choice)
+                                                            println!("Unknown action '{}'", choice);
                                                         }
                                                     }
                                                 }
@@ -210,42 +232,44 @@ pub async fn choose_account_action(twilio: &Client) {
                                         }
                                     }
                                     "suspended" => {
-                                        if let Some(account_action) = get_action_choice_from_user(
-                                            vec!["Change name".into(), "Activate".into()],
-                                            "Select an action: ",
-                                        ) {
+                                        if
+                                            let Some(account_action) = get_action_choice_from_user(
+                                                vec!["Change name".into(), "Activate".into()],
+                                                "Select an action: "
+                                            )
+                                        {
                                             match account_action {
-                                                ActionChoice::Back => break,
+                                                ActionChoice::Back => {
+                                                    break;
+                                                }
                                                 ActionChoice::Exit => process::exit(0),
                                                 ActionChoice::Other(choice) => {
                                                     match choice.as_str() {
                                                         "Change name" => {
                                                             change_account_name(
                                                                 twilio,
-                                                                &selected_account.sid,
-                                                            )
-                                                            .await;
-                                                            accounts[selected_account_index
-                                                                .expect(
-                                                                    "Selected account is unknown",
-                                                                )]
-                                                            .friendly_name = friendly_name.clone();
+                                                                &selected_account.sid
+                                                            ).await;
+                                                            accounts[
+                                                                selected_account_index.expect(
+                                                                    "Selected account is unknown"
+                                                                )
+                                                            ].friendly_name = friendly_name.clone();
                                                         }
                                                         "Activate" => {
                                                             activate_account(
                                                                 twilio,
-                                                                &selected_account.sid,
-                                                            )
-                                                            .await;
-                                                            accounts[selected_account_index
-                                                                .expect(
-                                                                    "Selected account is unknown",
-                                                                )]
-                                                            .status = Status::Active;
+                                                                &selected_account.sid
+                                                            ).await;
+                                                            accounts[
+                                                                selected_account_index.expect(
+                                                                    "Selected account is unknown"
+                                                                )
+                                                            ].status = Status::Active;
                                                         }
 
                                                         _ => {
-                                                            println!("Unknown action '{}'", choice)
+                                                            println!("Unknown action '{}'", choice);
                                                         }
                                                     }
                                                 }
@@ -271,7 +295,9 @@ pub async fn choose_account_action(twilio: &Client) {
                         }
                     }
                 }
-                Action::Back => break,
+                Action::Back => {
+                    break;
+                }
                 Action::Exit => process::exit(0),
             }
         } else {
@@ -281,18 +307,18 @@ pub async fn choose_account_action(twilio: &Client) {
 }
 
 async fn change_account_name(twilio: &Client, account_sid: &str) {
-    let friendly_name_prompt =
-        Text::new("Provide a name:").with_validator(|val: &str| match val.len() > 0 {
+    let friendly_name_prompt = Text::new("Provide a name:").with_validator(|val: &str| {
+        match val.len() > 0 {
             true => Ok(Validation::Valid),
             false => Ok(Validation::Invalid("Enter at least one character".into())),
-        });
+        }
+    });
 
     if let Some(friendly_name) = prompt_user(friendly_name_prompt) {
         println!("Updating account...");
         let updated_account = twilio
             .accounts()
-            .update(account_sid, Some(&friendly_name), None)
-            .await
+            .update(account_sid, Some(&friendly_name), None).await
             .unwrap_or_else(|error| panic!("{}", error));
 
         println!("{:#?}", updated_account);
@@ -301,16 +327,16 @@ async fn change_account_name(twilio: &Client, account_sid: &str) {
 }
 
 async fn activate_account(twilio: &Client, account_sid: &str) {
-    let confirmation_prompt =
-        Confirm::new("Are you sure you wish to activate this account? (Yes / No)");
+    let confirmation_prompt = Confirm::new("Are you sure you wish to activate this account?")
+        .with_placeholder("N")
+        .with_default(false);
 
     if let Some(confirmation) = prompt_user(confirmation_prompt) {
         if confirmation == true {
             println!("Activating account...");
             twilio
                 .accounts()
-                .update(account_sid, None, Some(&Status::Suspended))
-                .await
+                .update(account_sid, None, Some(&Status::Suspended)).await
                 .unwrap_or_else(|error| panic!("{}", error));
 
             println!("Account activated.");
@@ -322,16 +348,18 @@ async fn activate_account(twilio: &Client, account_sid: &str) {
 }
 
 async fn suspend_account(twilio: &Client, account_sid: &str) {
-    let confirmation_prompt =
-        Confirm::new("Are you sure you wish to suspend this account? Any activity will be disabled until the account is re-activated. (Yes / No)");
+    let confirmation_prompt = Confirm::new(
+        "Are you sure you wish to suspend this account? Any activity will be disabled until the account is re-activated."
+    )
+        .with_placeholder("N")
+        .with_default(false);
 
     if let Some(confirmation) = prompt_user(confirmation_prompt) {
         if confirmation == true {
             println!("Suspending account...");
             let res = twilio
                 .accounts()
-                .update(account_sid, None, Some(&Status::Suspended))
-                .await
+                .update(account_sid, None, Some(&Status::Suspended)).await
                 .unwrap_or_else(|error| panic!("{}", error));
 
             println!("{}", res);
@@ -344,16 +372,18 @@ async fn suspend_account(twilio: &Client, account_sid: &str) {
 }
 
 async fn close_account(twilio: &Client, account_sid: &str) {
-    let confirmation_prompt =
-        Confirm::new("Are you sure you wish to Close this account? Activity will be disabled and this action cannot be reversed. (Yes / No)");
+    let confirmation_prompt = Confirm::new(
+        "Are you sure you wish to Close this account? Activity will be disabled and this action cannot be reversed."
+    )
+        .with_placeholder("N")
+        .with_default(false);
 
     if let Some(confirmation) = prompt_user(confirmation_prompt) {
         if confirmation == true {
             println!("Closing account...");
             twilio
                 .accounts()
-                .update(account_sid, None, Some(&Status::Suspended))
-                .await
+                .update(account_sid, None, Some(&Status::Suspended)).await
                 .unwrap_or_else(|error| panic!("{}", error));
 
             println!(

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -1,16 +1,17 @@
-use std::{process, str::FromStr};
+use std::{ process, str::FromStr };
 
 use chrono::Datelike;
-use inquire::{validator::Validation, Confirm, DateSelect, Select, Text};
+use inquire::{ validator::Validation, Confirm, DateSelect, Select, Text };
 use strum::IntoEnumIterator;
-use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{
-    conversation::{Conversation, State, UpdateConversation},
-    Client, ErrorKind,
-};
+use strum_macros::{ Display, EnumIter, EnumString };
+use twilly::{ conversation::{ Conversation, State, UpdateConversation }, Client, ErrorKind };
 use twilly_cli::{
-    get_action_choice_from_user, get_filter_choice_from_user, prompt_user, prompt_user_selection,
-    ActionChoice, FilterChoice,
+    get_action_choice_from_user,
+    get_filter_choice_from_user,
+    prompt_user,
+    prompt_user_selection,
+    ActionChoice,
+    FilterChoice,
 };
 
 #[derive(Clone, Display, EnumIter, EnumString)]
@@ -36,18 +37,21 @@ pub async fn choose_conversation_action(twilio: &Client) {
         if let Some(action) = prompt_user_selection(action_selection_prompt) {
             match action {
                 Action::GetConversation => {
-                    let conversation_sid_prompt =
-                        Text::new("Please provide a conversation SID, or unique name:")
-                            .with_placeholder("CH...")
-                            .with_validator(|val: &str| {
-                                if val.starts_with("CH") && val.len() == 34 {
-                                    Ok(Validation::Valid)
-                                } else {
-                                    Ok(Validation::Invalid(
-                                        "Conversation SID should be 34 characters in length".into(),
-                                    ))
-                                }
-                            });
+                    let conversation_sid_prompt = Text::new(
+                        "Please provide a conversation SID, or unique name:"
+                    )
+                        .with_placeholder("CH...")
+                        .with_validator(|val: &str| {
+                            if val.starts_with("CH") && val.len() == 34 {
+                                Ok(Validation::Valid)
+                            } else {
+                                Ok(
+                                    Validation::Invalid(
+                                        "Conversation SID should be 34 characters in length".into()
+                                    )
+                                )
+                            }
+                        });
 
                     if let Some(conversation_sid) = prompt_user(conversation_sid_prompt) {
                         match twilio.conversations().get(&conversation_sid).await {
@@ -55,59 +59,67 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                 println!("Conversation found.");
                                 println!();
 
-                                if let Some(action_choice) = get_action_choice_from_user(
-                                    vec![String::from("List Details"), String::from("Delete")],
-                                    "Select an action: ",
-                                ) {
+                                if
+                                    let Some(action_choice) = get_action_choice_from_user(
+                                        vec![String::from("List Details"), String::from("Delete")],
+                                        "Select an action: "
+                                    )
+                                {
                                     match action_choice {
-                                        ActionChoice::Back => break,
+                                        ActionChoice::Back => {
+                                            break;
+                                        }
                                         ActionChoice::Exit => process::exit(0),
-                                        ActionChoice::Other(choice) => match choice.as_str() {
-                                            "List Details" => {
-                                                println!("{:#?}", conversation);
-                                                println!();
-                                            }
-                                            "Delete" => {
-                                                let confirm_prompt = Confirm::new(
-                                                "Are you sure to wish to delete the Conversation? (Yes / No)",
-                                            );
-                                                let confirmation = prompt_user(confirm_prompt);
-                                                if confirmation.is_some()
-                                                    && confirmation.unwrap() == true
-                                                {
-                                                    println!("Deleting Conversation...");
-                                                    twilio
-                                                        .conversations()
-                                                        .delete(&conversation_sid)
-                                                        .await
-                                                        .unwrap_or_else(|error| {
-                                                            panic!("{}", error)
-                                                        });
-                                                    println!("Conversation deleted.");
+                                        ActionChoice::Other(choice) =>
+                                            match choice.as_str() {
+                                                "List Details" => {
+                                                    println!("{:#?}", conversation);
                                                     println!();
                                                 }
+                                                "Delete" => {
+                                                    let confirm_prompt = Confirm::new(
+                                                        "Are you sure to wish to delete the Conversation?"
+                                                    )
+                                                        .with_placeholder("N")
+                                                        .with_default(false);
+                                                    let confirmation = prompt_user(confirm_prompt);
+                                                    if
+                                                        confirmation.is_some() &&
+                                                        confirmation.unwrap() == true
+                                                    {
+                                                        println!("Deleting Conversation...");
+                                                        twilio
+                                                            .conversations()
+                                                            .delete(&conversation_sid).await
+                                                            .unwrap_or_else(|error| {
+                                                                panic!("{}", error)
+                                                            });
+                                                        println!("Conversation deleted.");
+                                                        println!();
+                                                    }
+                                                }
+                                                _ => println!("Unknown action '{}'", choice),
                                             }
-                                            _ => println!("Unknown action '{}'", choice),
-                                        },
                                     }
                                 } else {
                                     break;
                                 }
                             }
-                            Err(error) => match error.kind {
-                                ErrorKind::TwilioError(twilio_error) => {
-                                    if twilio_error.status == 404 {
-                                        println!(
-                                            "A Conversation with SID '{}' was not found.",
-                                            &conversation_sid
-                                        );
-                                        println!("");
-                                    } else {
-                                        panic!("{}", twilio_error)
+                            Err(error) =>
+                                match error.kind {
+                                    ErrorKind::TwilioError(twilio_error) => {
+                                        if twilio_error.status == 404 {
+                                            println!(
+                                                "A Conversation with SID '{}' was not found.",
+                                                &conversation_sid
+                                            );
+                                            println!("");
+                                        } else {
+                                            panic!("{}", twilio_error);
+                                        }
                                     }
+                                    _ => panic!("{}", error),
                                 }
-                                _ => panic!("{}", error),
-                            },
                         }
                     }
                 }
@@ -118,48 +130,56 @@ pub async fn choose_conversation_action(twilio: &Client) {
                     let mut user_filtered_dates = false;
 
                     let filter_dates_prompt = Confirm::new(
-                        "Would you like to filter between specified dates? (Yes / No)",
-                    );
+                        "Would you like to filter between specified dates?"
+                    )
+                        .with_placeholder("N")
+                        .with_default(false);
 
                     if let Some(decision) = prompt_user(filter_dates_prompt) {
                         if decision == true {
                             user_filtered_dates = true;
                             let utc_now = chrono::Utc::now();
                             let utc_one_year_ago = utc_now - chrono::Duration::days(365);
-                            if let Some(user_start_date) = get_date_from_user(
-                                "Choose a start date:",
-                                Some(DateRange {
-                                    minimum_date: chrono::NaiveDate::from_ymd_opt(
-                                        utc_one_year_ago.year(),
-                                        utc_one_year_ago.month(),
-                                        utc_one_year_ago.day(),
-                                    )
-                                    .unwrap(),
-                                    maximum_date: chrono::NaiveDate::from_ymd_opt(
-                                        utc_now.year(),
-                                        utc_now.month(),
-                                        utc_now.day(),
-                                    )
-                                    .unwrap(),
-                                }),
-                            ) {
+                            if
+                                let Some(user_start_date) = get_date_from_user(
+                                    "Choose a start date:",
+                                    Some(DateRange {
+                                        minimum_date: chrono::NaiveDate
+                                            ::from_ymd_opt(
+                                                utc_one_year_ago.year(),
+                                                utc_one_year_ago.month(),
+                                                utc_one_year_ago.day()
+                                            )
+                                            .unwrap(),
+                                        maximum_date: chrono::NaiveDate
+                                            ::from_ymd_opt(
+                                                utc_now.year(),
+                                                utc_now.month(),
+                                                utc_now.day()
+                                            )
+                                            .unwrap(),
+                                    })
+                                )
+                            {
                                 start_date = Some(user_start_date);
                                 end_date = get_date_from_user(
                                     "Choose an end date:",
                                     Some(DateRange {
-                                        minimum_date: chrono::NaiveDate::from_ymd_opt(
-                                            user_start_date.year_ce().1.try_into().unwrap(),
-                                            user_start_date.month0() + 1,
-                                            user_start_date.day0() + 1,
-                                        )
-                                        .unwrap(),
-                                        maximum_date: chrono::NaiveDate::from_ymd_opt(
-                                            utc_now.year(),
-                                            utc_now.month(),
-                                            utc_now.day(),
-                                        )
-                                        .unwrap(),
-                                    }),
+                                        minimum_date: chrono::NaiveDate
+                                            ::from_ymd_opt(
+                                                user_start_date.year_ce().1.try_into().unwrap(),
+                                                user_start_date.month0() + 1,
+                                                user_start_date.day0() + 1
+                                            )
+                                            .unwrap(),
+                                        maximum_date: chrono::NaiveDate
+                                            ::from_ymd_opt(
+                                                utc_now.year(),
+                                                utc_now.month(),
+                                                utc_now.day()
+                                            )
+                                            .unwrap(),
+                                    })
                                 );
                             }
                         }
@@ -167,13 +187,18 @@ pub async fn choose_conversation_action(twilio: &Client) {
 
                     // Only continue if the user filtered by dates *and* provided both options.
                     // If they didn't then they must of cancelled the operation.
-                    if !user_filtered_dates
-                        || user_filtered_dates && (start_date.is_some() && end_date.is_some())
+                    if
+                        !user_filtered_dates ||
+                        (user_filtered_dates && start_date.is_some() && end_date.is_some())
                     {
-                        if let Some(filter_choice) = get_filter_choice_from_user(
-                            State::iter().map(|state| state.to_string()).collect(),
-                            "Filter by state? ",
-                        ) {
+                        if
+                            let Some(filter_choice) = get_filter_choice_from_user(
+                                State::iter()
+                                    .map(|state| state.to_string())
+                                    .collect(),
+                                "Filter by state? "
+                            )
+                        {
                             let state = match filter_choice {
                                 FilterChoice::Any => None,
                                 FilterChoice::Other(choice) => {
@@ -184,8 +209,7 @@ pub async fn choose_conversation_action(twilio: &Client) {
                             println!("Fetching conversations...");
                             let mut conversations = twilio
                                 .conversations()
-                                .list(start_date, end_date, state)
-                                .await
+                                .list(start_date, end_date, state).await
                                 .unwrap_or_else(|error| panic!("{}", error));
 
                             let number_of_conversations = conversations.len();
@@ -202,29 +226,38 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                 loop {
                                     // If we know the index (a.k.a it hasn't been cleared by some other operation)
                                     // then use this conversation otherwise let the user choice.
-                                    let selected_conversation = if let Some(index) =
-                                        selected_conversation_index
+                                    let selected_conversation = if
+                                        let Some(index) = selected_conversation_index
                                     {
                                         &mut conversations[index]
                                     } else {
-                                        if let Some(action_choice) = get_action_choice_from_user(
-                                            conversations
-                                                .iter()
-                                                .map(|conv| {
-                                                    let display_name = match &conv.unique_name {
-                                                        Some(unique_name) => format!(
-                                                            "({}) {} - {}",
-                                                            conv.sid, unique_name, conv.state
-                                                        ),
-                                                        None => {
-                                                            format!("{} - {}", conv.sid, conv.state)
-                                                        }
-                                                    };
-                                                    display_name
-                                                })
-                                                .collect::<Vec<String>>(),
-                                            "Conversations: ",
-                                        ) {
+                                        if
+                                            let Some(action_choice) = get_action_choice_from_user(
+                                                conversations
+                                                    .iter()
+                                                    .map(|conv| {
+                                                        let display_name = match &conv.unique_name {
+                                                            Some(unique_name) =>
+                                                                format!(
+                                                                    "({}) {} - {}",
+                                                                    conv.sid,
+                                                                    unique_name,
+                                                                    conv.state
+                                                                ),
+                                                            None => {
+                                                                format!(
+                                                                    "{} - {}",
+                                                                    conv.sid,
+                                                                    conv.state
+                                                                )
+                                                            }
+                                                        };
+                                                        display_name
+                                                    })
+                                                    .collect::<Vec<String>>(),
+                                                "Conversations: "
+                                            )
+                                        {
                                             match action_choice {
                                                 ActionChoice::Back => {
                                                     break;
@@ -234,7 +267,9 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                                     let conversation_position = conversations
                                                         .iter()
                                                         .position(|conv| conv.sid == choice[..34])
-                                                        .expect("Could not find conversation in existing conversation list");
+                                                        .expect(
+                                                            "Could not find conversation in existing conversation list"
+                                                        );
 
                                                     selected_conversation_index =
                                                         Some(conversation_position);
@@ -247,194 +282,202 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                     };
 
                                     match selected_conversation.state {
-                                        State::Closed => loop {
-                                            if let Some(conversation_action) =
-                                                get_action_choice_from_user(
-                                                    vec![
-                                                        String::from("List details"),
-                                                        String::from("Delete"),
-                                                    ],
-                                                    "Select an action: ",
-                                                )
-                                            {
-                                                match conversation_action {
-                                                    ActionChoice::Back => {
-                                                        selected_conversation_index = None;
-                                                        break;
-                                                    }
-                                                    ActionChoice::Exit => process::exit(0),
-                                                    ActionChoice::Other(choice) => match choice
-                                                        .as_str()
-                                                    {
-                                                        "List details" => {
-                                                            println!(
-                                                                "{:#?}",
-                                                                selected_conversation
-                                                            );
-                                                            println!();
-                                                        }
-                                                        "Delete" => {
-                                                            delete_conversation(
-                                                                twilio,
-                                                                &selected_conversation.sid,
-                                                            )
-                                                            .await;
-                                                            conversations.remove(
-                                                                selected_conversation_index
-                                                                    .expect("Could not find conversation in existing conversation list"),
-                                                            );
+                                        State::Closed =>
+                                            loop {
+                                                if
+                                                    let Some(conversation_action) =
+                                                        get_action_choice_from_user(
+                                                            vec![
+                                                                String::from("List details"),
+                                                                String::from("Delete")
+                                                            ],
+                                                            "Select an action: "
+                                                        )
+                                                {
+                                                    match conversation_action {
+                                                        ActionChoice::Back => {
                                                             selected_conversation_index = None;
                                                             break;
                                                         }
-                                                        _ => {
-                                                            println!("Unknown action '{}'", choice)
-                                                        }
-                                                    },
-                                                }
-                                            } else {
-                                                selected_conversation_index = None;
-                                                break;
-                                            }
-                                        },
-                                        State::Inactive => loop {
-                                            if let Some(conversation_action) =
-                                                get_action_choice_from_user(
-                                                    vec![
-                                                        String::from("List details"),
-                                                        String::from("Re-activate"),
-                                                        String::from("Delete"),
-                                                    ],
-                                                    "Select an action: ",
-                                                )
-                                            {
-                                                match conversation_action {
-                                                    ActionChoice::Back => {
-                                                        selected_conversation_index = None;
-                                                        break;
+                                                        ActionChoice::Exit => process::exit(0),
+                                                        ActionChoice::Other(choice) =>
+                                                            match choice.as_str() {
+                                                                "List details" => {
+                                                                    println!(
+                                                                        "{:#?}",
+                                                                        selected_conversation
+                                                                    );
+                                                                    println!();
+                                                                }
+                                                                "Delete" => {
+                                                                    delete_conversation(
+                                                                        twilio,
+                                                                        &selected_conversation.sid
+                                                                    ).await;
+                                                                    conversations.remove(
+                                                                        selected_conversation_index.expect(
+                                                                            "Could not find conversation in existing conversation list"
+                                                                        )
+                                                                    );
+                                                                    selected_conversation_index =
+                                                                        None;
+                                                                    break;
+                                                                }
+                                                                _ => {
+                                                                    println!("Unknown action '{}'", choice);
+                                                                }
+                                                            }
                                                     }
-                                                    ActionChoice::Exit => process::exit(0),
-                                                    ActionChoice::Other(choice) => match choice
-                                                        .as_str()
-                                                    {
-                                                        "List details" => {
-                                                            println!(
-                                                                "{:#?}",
-                                                                selected_conversation
-                                                            );
-                                                            println!();
-                                                        }
-                                                        "Re-activate" => {
-                                                            let updated_conversation =
-                                                                update_conversation(
-                                                                    twilio,
-                                                                    &selected_conversation.sid,
-                                                                    UpdateConversation {
-                                                                        state: Some(State::Active),
-                                                                        friendly_name: None,
-                                                                        unique_name: None,
-                                                                        attributes: None,
-                                                                        timers: None,
-                                                                    },
-                                                                )
-                                                                .await;
-                                                            conversations
-                                                                [selected_conversation_index
-                                                                    .expect("Could not find conversation in existing conversation list")] =
-                                                                updated_conversation;
-                                                            break;
-                                                        }
-                                                        "Delete" => {
-                                                            delete_conversation(
-                                                                twilio,
-                                                                &selected_conversation.sid,
-                                                            )
-                                                            .await;
-                                                            conversations.remove(
-                                                                selected_conversation_index
-                                                                    .expect("Could not find conversation in existing conversation list"),
-                                                            );
+                                                } else {
+                                                    selected_conversation_index = None;
+                                                    break;
+                                                }
+                                            }
+                                        State::Inactive =>
+                                            loop {
+                                                if
+                                                    let Some(conversation_action) =
+                                                        get_action_choice_from_user(
+                                                            vec![
+                                                                String::from("List details"),
+                                                                String::from("Re-activate"),
+                                                                String::from("Delete")
+                                                            ],
+                                                            "Select an action: "
+                                                        )
+                                                {
+                                                    match conversation_action {
+                                                        ActionChoice::Back => {
                                                             selected_conversation_index = None;
                                                             break;
                                                         }
-                                                        _ => {
-                                                            println!("Unknown action '{}'", choice)
-                                                        }
-                                                    },
-                                                }
-                                            } else {
-                                                selected_conversation_index = None;
-                                                break;
-                                            }
-                                        },
-                                        State::Active => loop {
-                                            if let Some(conversation_action) =
-                                                get_action_choice_from_user(
-                                                    vec![
-                                                        String::from("List details"),
-                                                        String::from("De-activate"),
-                                                        String::from("Delete"),
-                                                    ],
-                                                    "Select an action: ",
-                                                )
-                                            {
-                                                match conversation_action {
-                                                    ActionChoice::Back => {
-                                                        selected_conversation_index = None;
-                                                        break;
+                                                        ActionChoice::Exit => process::exit(0),
+                                                        ActionChoice::Other(choice) =>
+                                                            match choice.as_str() {
+                                                                "List details" => {
+                                                                    println!(
+                                                                        "{:#?}",
+                                                                        selected_conversation
+                                                                    );
+                                                                    println!();
+                                                                }
+                                                                "Re-activate" => {
+                                                                    let updated_conversation =
+                                                                        update_conversation(
+                                                                            twilio,
+                                                                            &selected_conversation.sid,
+                                                                            UpdateConversation {
+                                                                                state: Some(
+                                                                                    State::Active
+                                                                                ),
+                                                                                friendly_name: None,
+                                                                                unique_name: None,
+                                                                                attributes: None,
+                                                                                timers: None,
+                                                                            }
+                                                                        ).await;
+                                                                    conversations[
+                                                                        selected_conversation_index.expect(
+                                                                            "Could not find conversation in existing conversation list"
+                                                                        )
+                                                                    ] = updated_conversation;
+                                                                    break;
+                                                                }
+                                                                "Delete" => {
+                                                                    delete_conversation(
+                                                                        twilio,
+                                                                        &selected_conversation.sid
+                                                                    ).await;
+                                                                    conversations.remove(
+                                                                        selected_conversation_index.expect(
+                                                                            "Could not find conversation in existing conversation list"
+                                                                        )
+                                                                    );
+                                                                    selected_conversation_index =
+                                                                        None;
+                                                                    break;
+                                                                }
+                                                                _ => {
+                                                                    println!("Unknown action '{}'", choice);
+                                                                }
+                                                            }
                                                     }
-                                                    ActionChoice::Exit => process::exit(0),
-                                                    ActionChoice::Other(choice) => match choice
-                                                        .as_str()
-                                                    {
-                                                        "List details" => {
-                                                            println!(
-                                                                "{:#?}",
-                                                                selected_conversation
-                                                            );
-                                                            println!();
-                                                        }
-                                                        "De-activate" => {
-                                                            let updated_conversation =
-                                                                update_conversation(
-                                                                    twilio,
-                                                                    &selected_conversation.sid,
-                                                                    UpdateConversation {
-                                                                        state: Some(
-                                                                            State::Inactive,
-                                                                        ),
-                                                                        friendly_name: None,
-                                                                        unique_name: None,
-                                                                        attributes: None,
-                                                                        timers: None,
-                                                                    },
-                                                                )
-                                                                .await;
-                                                            conversations
-                                                                [selected_conversation_index
-                                                                    .expect("Could not find conversation in existing conversation list")] =
-                                                                updated_conversation;
-                                                            break;
-                                                        }
-                                                        "Delete" => {
-                                                            delete_conversation(
-                                                                twilio,
-                                                                &selected_conversation.sid,
-                                                            )
-                                                            .await;
-                                                            conversations.remove(
-                                                                selected_conversation_index
-                                                                    .expect("Could not find conversation in existing conversation list"),
-                                                            );
+                                                } else {
+                                                    selected_conversation_index = None;
+                                                    break;
+                                                }
+                                            }
+                                        State::Active =>
+                                            loop {
+                                                if
+                                                    let Some(conversation_action) =
+                                                        get_action_choice_from_user(
+                                                            vec![
+                                                                String::from("List details"),
+                                                                String::from("De-activate"),
+                                                                String::from("Delete")
+                                                            ],
+                                                            "Select an action: "
+                                                        )
+                                                {
+                                                    match conversation_action {
+                                                        ActionChoice::Back => {
                                                             selected_conversation_index = None;
                                                             break;
                                                         }
-                                                        _ => {
-                                                            println!("Unknown action '{}'", choice)
-                                                        }
-                                                    },
+                                                        ActionChoice::Exit => process::exit(0),
+                                                        ActionChoice::Other(choice) =>
+                                                            match choice.as_str() {
+                                                                "List details" => {
+                                                                    println!(
+                                                                        "{:#?}",
+                                                                        selected_conversation
+                                                                    );
+                                                                    println!();
+                                                                }
+                                                                "De-activate" => {
+                                                                    let updated_conversation =
+                                                                        update_conversation(
+                                                                            twilio,
+                                                                            &selected_conversation.sid,
+                                                                            UpdateConversation {
+                                                                                state: Some(
+                                                                                    State::Inactive
+                                                                                ),
+                                                                                friendly_name: None,
+                                                                                unique_name: None,
+                                                                                attributes: None,
+                                                                                timers: None,
+                                                                            }
+                                                                        ).await;
+                                                                    conversations[
+                                                                        selected_conversation_index.expect(
+                                                                            "Could not find conversation in existing conversation list"
+                                                                        )
+                                                                    ] = updated_conversation;
+                                                                    break;
+                                                                }
+                                                                "Delete" => {
+                                                                    delete_conversation(
+                                                                        twilio,
+                                                                        &selected_conversation.sid
+                                                                    ).await;
+                                                                    conversations.remove(
+                                                                        selected_conversation_index.expect(
+                                                                            "Could not find conversation in existing conversation list"
+                                                                        )
+                                                                    );
+                                                                    selected_conversation_index =
+                                                                        None;
+                                                                    break;
+                                                                }
+                                                                _ => {
+                                                                    println!("Unknown action '{}'", choice);
+                                                                }
+                                                            }
+                                                    }
                                                 }
                                             }
-                                        },
                                     }
                                 }
                             }
@@ -442,18 +485,21 @@ pub async fn choose_conversation_action(twilio: &Client) {
                     }
                 }
                 Action::DeleteConversation => {
-                    let conversation_sid_prompt =
-                        Text::new("Please provide a conversation SID, or unique name:")
-                            .with_placeholder("CH...")
-                            .with_validator(|val: &str| {
-                                if val.starts_with("CH") && val.len() == 34 {
-                                    Ok(Validation::Valid)
-                                } else {
-                                    Ok(Validation::Invalid(
-                                        "Conversation SID should be 34 characters in length".into(),
-                                    ))
-                                }
-                            });
+                    let conversation_sid_prompt = Text::new(
+                        "Please provide a conversation SID, or unique name:"
+                    )
+                        .with_placeholder("CH...")
+                        .with_validator(|val: &str| {
+                            if val.starts_with("CH") && val.len() == 34 {
+                                Ok(Validation::Valid)
+                            } else {
+                                Ok(
+                                    Validation::Invalid(
+                                        "Conversation SID should be 34 characters in length".into()
+                                    )
+                                )
+                            }
+                        });
 
                     if let Some(conversation_sid) = prompt_user(conversation_sid_prompt) {
                         delete_conversation(twilio, &conversation_sid).await;
@@ -463,34 +509,40 @@ pub async fn choose_conversation_action(twilio: &Client) {
                 }
                 Action::DeleteAllConversations => {
                     let first_confirmation_prompt = Confirm::new(
-                        "Are you sure to wish to delete **all** Conversations? (Yes / No)",
-                    );
-                    let second_confirmation_prompt =
-                        Confirm::new("Are you double sure? There is no going back. (Yes / No)");
+                        "Are you sure to wish to delete **all** Conversations?"
+                    )
+                        .with_placeholder("N")
+                        .with_default(false);
+                    let second_confirmation_prompt = Confirm::new(
+                        "Are you double sure? There is no going back."
+                    )
+                        .with_placeholder("N")
+                        .with_default(false);
 
                     if let Some(first_confirmation) = prompt_user(first_confirmation_prompt) {
                         if first_confirmation == true {
-                            if let Some(second_confirmation) =
-                                prompt_user(second_confirmation_prompt)
+                            if
+                                let Some(second_confirmation) = prompt_user(
+                                    second_confirmation_prompt
+                                )
                             {
                                 if second_confirmation == true {
                                     println!("Proceeding with deletion. Please wait...");
                                     let conversations = twilio
                                         .conversations()
-                                        .list(None, None, None)
-                                        .await
+                                        .list(None, None, None).await
                                         .unwrap_or_else(|error| panic!("{}", error));
 
                                     for conversation in conversations {
                                         twilio
                                             .conversations()
-                                            .delete(&conversation.sid)
-                                            .await
+                                            .delete(&conversation.sid).await
                                             .unwrap_or_else(|error| panic!("{}", error));
                                         // This is not particularly smart but this prevents overwhelming Twilio.
                                         // Delete 1 Conversation per second. The rate could be much higher than this.
-                                        tokio::time::sleep(tokio::time::Duration::from_secs(1))
-                                            .await;
+                                        tokio::time::sleep(
+                                            tokio::time::Duration::from_secs(1)
+                                        ).await;
                                     }
 
                                     println!("All conversations deleted.");
@@ -504,7 +556,9 @@ pub async fn choose_conversation_action(twilio: &Client) {
                     println!("Operation canceled. No changes were made.");
                     println!("");
                 }
-                Action::Back => break,
+                Action::Back => {
+                    break;
+                }
                 Action::Exit => process::exit(0),
             }
         } else {
@@ -518,7 +572,7 @@ pub async fn choose_conversation_action(twilio: &Client) {
 async fn update_conversation(
     twilio: &Client,
     sid: &str,
-    updates: UpdateConversation,
+    updates: UpdateConversation
 ) -> Conversation {
     match twilio.conversations().update(sid, updates).await {
         Ok(updated_conversation) => {
@@ -534,8 +588,9 @@ async fn update_conversation(
 /// Prompts the user for confirmation before deleting the conversation with
 /// the SID provided. Will panic if the delete operation fails.
 async fn delete_conversation(twilio: &Client, sid: &str) {
-    let confirmation_prompt =
-        Confirm::new("Are you sure to wish to delete the Conversation? (Yes / No)");
+    let confirmation_prompt = Confirm::new("Are you sure to wish to delete the Conversation?")
+        .with_placeholder("N")
+        .with_default(false);
 
     if let Some(confirmation) = prompt_user(confirmation_prompt) {
         if confirmation == true {
@@ -544,17 +599,18 @@ async fn delete_conversation(twilio: &Client, sid: &str) {
                     println!("Conversation deleted.");
                     println!("");
                 }
-                Err(error) => match error.kind {
-                    ErrorKind::TwilioError(twilio_error) => {
-                        if twilio_error.status == 404 {
-                            println!("A Conversation with SID '{}' was not found.", &sid);
-                            println!("");
-                        } else {
-                            panic!("{}", twilio_error)
+                Err(error) =>
+                    match error.kind {
+                        ErrorKind::TwilioError(twilio_error) => {
+                            if twilio_error.status == 404 {
+                                println!("A Conversation with SID '{}' was not found.", &sid);
+                                println!("");
+                            } else {
+                                panic!("{}", twilio_error)
+                            }
                         }
+                        _ => panic!("{}", error),
                     }
-                    _ => panic!("{}", error),
-                },
             }
         }
     }
@@ -570,28 +626,31 @@ fn get_date_from_user(message: &str, date_range: Option<DateRange>) -> Option<ch
         Some(date_range) => {
             let date_selection_prompt = DateSelect::new(message)
                 .with_min_date(
-                    chrono::NaiveDate::from_ymd_opt(
-                        date_range.minimum_date.year(),
-                        date_range.minimum_date.month(),
-                        date_range.minimum_date.day(),
-                    )
-                    .unwrap(),
+                    chrono::NaiveDate
+                        ::from_ymd_opt(
+                            date_range.minimum_date.year(),
+                            date_range.minimum_date.month(),
+                            date_range.minimum_date.day()
+                        )
+                        .unwrap()
                 )
                 .with_max_date(
-                    chrono::NaiveDate::from_ymd_opt(
-                        date_range.maximum_date.year(),
-                        date_range.maximum_date.month(),
-                        date_range.maximum_date.day(),
-                    )
-                    .unwrap(),
+                    chrono::NaiveDate
+                        ::from_ymd_opt(
+                            date_range.maximum_date.year(),
+                            date_range.maximum_date.month(),
+                            date_range.maximum_date.day()
+                        )
+                        .unwrap()
                 )
                 .with_week_start(chrono::Weekday::Mon);
 
             prompt_user(date_selection_prompt)
         }
         None => {
-            let date_selection_prompt =
-                DateSelect::new(message).with_week_start(chrono::Weekday::Mon);
+            let date_selection_prompt = DateSelect::new(message).with_week_start(
+                chrono::Weekday::Mon
+            );
             prompt_user(date_selection_prompt)
         }
     };

--- a/twilly_cli/src/main.rs
+++ b/twilly_cli/src/main.rs
@@ -28,9 +28,10 @@ async fn main() {
         config = request_credentials();
     } else {
         if Confirm::new(&format!(
-            "Account ({}) found in memory. Use this profile? (Yes / No)",
+            "Account ({}) found in memory. Use this profile?",
             config.account_sid
-        ))
+        )).with_default(true)
+        .with_placeholder("Y")
         .prompt()
         .unwrap()
         {

--- a/twilly_cli/src/main.rs
+++ b/twilly_cli/src/main.rs
@@ -30,7 +30,8 @@ async fn main() {
         if Confirm::new(&format!(
             "Account ({}) found in memory. Use this profile?",
             config.account_sid
-        )).with_default(true)
+        ))
+        .with_default(true)
         .with_placeholder("Y")
         .prompt()
         .unwrap()

--- a/twilly_cli/src/sync.rs
+++ b/twilly_cli/src/sync.rs
@@ -6,11 +6,11 @@ mod maps;
 
 use std::process;
 
-use inquire::{Confirm, Select, Text};
+use inquire::{ Confirm, Select, Text };
 use strum::IntoEnumIterator;
-use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{sync::services::CreateOrUpdateParams, Client};
-use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+use strum_macros::{ Display, EnumIter, EnumString };
+use twilly::{ sync::services::CreateOrUpdateParams, Client };
+use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
@@ -31,8 +31,7 @@ pub async fn choose_sync_resource(twilio: &Client) {
     let mut sync_services = twilio
         .sync()
         .services()
-        .list()
-        .await
+        .list().await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_services.len() == 0 {
@@ -49,17 +48,24 @@ pub async fn choose_sync_resource(twilio: &Client) {
         } else {
             let mut existing_services = sync_services
                 .iter()
-                .map(|service| match &service.unique_name {
-                    Some(unique_name) => format!("({}) {}", service.sid, unique_name),
-                    None => match &service.friendly_name {
-                        Some(friendly_name) => format!("({}) {}", service.sid, friendly_name),
-                        None => format!("{}", service.sid),
-                    },
+                .map(|service| {
+                    match &service.unique_name {
+                        Some(unique_name) => format!("({}) {}", service.sid, unique_name),
+                        None =>
+                            match &service.friendly_name {
+                                Some(friendly_name) =>
+                                    format!("({}) {}", service.sid, friendly_name),
+                                None => format!("{}", service.sid),
+                            }
+                    }
                 })
                 .collect::<Vec<String>>();
             existing_services.push("Create Sync Service".into());
-            if let Some(action_choice) =
-                get_action_choice_from_user(existing_services, "Choose a Sync Service: ")
+            if
+                let Some(action_choice) = get_action_choice_from_user(
+                    existing_services,
+                    "Choose a Sync Service: "
+                )
             {
                 match action_choice {
                     ActionChoice::Back => {
@@ -68,14 +74,20 @@ pub async fn choose_sync_resource(twilio: &Client) {
                     ActionChoice::Exit => process::exit(0),
                     ActionChoice::Other(choice) => {
                         if choice == "Create Sync Service" {
-                            let friendly_name_prompt =
-                                Text::new("Enter a friendly name (empty for default):");
+                            let friendly_name_prompt = Text::new(
+                                "Enter a friendly name (empty for default):"
+                            );
 
                             if let Some(friendly_name) = prompt_user(friendly_name_prompt) {
-                                let acl_confirmation_prompt =
-                                    Confirm::new("Would you like to enable ACL? (Yes / No)");
+                                let acl_confirmation_prompt = Confirm::new(
+                                    "Would you like to enable ACL?"
+                                )
+                                    .with_placeholder("Y")
+                                    .with_default(true);
 
-                                if let Some(acl_confirmation) = prompt_user(acl_confirmation_prompt)
+                                if
+                                    let Some(acl_confirmation) =
+                                        prompt_user(acl_confirmation_prompt)
                                 {
                                     let sync_service = twilio
                                         .sync()
@@ -88,8 +100,7 @@ pub async fn choose_sync_resource(twilio: &Client) {
                                             reachability_webhooks_enabled: None,
                                             webhooks_from_rest_enabled: None,
                                             webhook_url: None,
-                                        })
-                                        .await
+                                        }).await
                                         .unwrap_or_else(|error| panic!("{}", error));
                                     sync_services.push(sync_service);
                                     selected_sync_service_index = Some(sync_services.len() - 1);
@@ -105,7 +116,7 @@ pub async fn choose_sync_resource(twilio: &Client) {
                                 .iter()
                                 .position(|sync_service| sync_service.sid == choice[1..35])
                                 .expect(
-                                    "Could not find Sync Service in existing Sync Service list",
+                                    "Could not find Sync Service in existing Sync Service list"
                                 );
 
                             selected_sync_service_index = Some(sync_service_position);
@@ -123,37 +134,41 @@ pub async fn choose_sync_resource(twilio: &Client) {
         if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
             match resource {
                 Action::Document => {
-                    documents::choose_document_action(&twilio, selected_sync_service).await
+                    documents::choose_document_action(&twilio, selected_sync_service).await;
                 }
                 Action::Map => maps::choose_map_action(&twilio, selected_sync_service).await,
                 Action::List => lists::choose_list_action(&twilio, selected_sync_service).await,
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_service);
-                    println!()
+                    println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt =
-                        Confirm::new("Are you sure to wish to delete the Sync Service? (Yes / No)");
+                    let confirm_prompt = Confirm::new(
+                        "Are you sure to wish to delete the Sync Service?"
+                    )
+                        .with_placeholder("N")
+                        .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Service...");
                         twilio
                             .sync()
                             .service(&selected_sync_service.sid)
-                            .delete()
-                            .await
+                            .delete().await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_services.remove(
                             selected_sync_service_index.expect(
-                                "Could not find Sync Service in existing Sync Services list",
-                            ),
+                                "Could not find Sync Service in existing Sync Services list"
+                            )
                         );
                         println!("Sync Service deleted.");
                         println!();
                         break;
                     }
                 }
-                Action::Back => break,
+                Action::Back => {
+                    break;
+                }
                 Action::Exit => process::exit(0),
             }
         }

--- a/twilly_cli/src/sync.rs
+++ b/twilly_cli/src/sync.rs
@@ -6,11 +6,11 @@ mod maps;
 
 use std::process;
 
-use inquire::{ Confirm, Select, Text };
+use inquire::{Confirm, Select, Text};
 use strum::IntoEnumIterator;
-use strum_macros::{ Display, EnumIter, EnumString };
-use twilly::{ sync::services::CreateOrUpdateParams, Client };
-use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{sync::services::CreateOrUpdateParams, Client};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
@@ -31,7 +31,8 @@ pub async fn choose_sync_resource(twilio: &Client) {
     let mut sync_services = twilio
         .sync()
         .services()
-        .list().await
+        .list()
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_services.len() == 0 {
@@ -48,24 +49,17 @@ pub async fn choose_sync_resource(twilio: &Client) {
         } else {
             let mut existing_services = sync_services
                 .iter()
-                .map(|service| {
-                    match &service.unique_name {
-                        Some(unique_name) => format!("({}) {}", service.sid, unique_name),
-                        None =>
-                            match &service.friendly_name {
-                                Some(friendly_name) =>
-                                    format!("({}) {}", service.sid, friendly_name),
-                                None => format!("{}", service.sid),
-                            }
-                    }
+                .map(|service| match &service.unique_name {
+                    Some(unique_name) => format!("({}) {}", service.sid, unique_name),
+                    None => match &service.friendly_name {
+                        Some(friendly_name) => format!("({}) {}", service.sid, friendly_name),
+                        None => format!("{}", service.sid),
+                    },
                 })
                 .collect::<Vec<String>>();
             existing_services.push("Create Sync Service".into());
-            if
-                let Some(action_choice) = get_action_choice_from_user(
-                    existing_services,
-                    "Choose a Sync Service: "
-                )
+            if let Some(action_choice) =
+                get_action_choice_from_user(existing_services, "Choose a Sync Service: ")
             {
                 match action_choice {
                     ActionChoice::Back => {
@@ -74,20 +68,16 @@ pub async fn choose_sync_resource(twilio: &Client) {
                     ActionChoice::Exit => process::exit(0),
                     ActionChoice::Other(choice) => {
                         if choice == "Create Sync Service" {
-                            let friendly_name_prompt = Text::new(
-                                "Enter a friendly name (empty for default):"
-                            );
+                            let friendly_name_prompt =
+                                Text::new("Enter a friendly name (empty for default):");
 
                             if let Some(friendly_name) = prompt_user(friendly_name_prompt) {
-                                let acl_confirmation_prompt = Confirm::new(
-                                    "Would you like to enable ACL?"
-                                )
-                                    .with_placeholder("Y")
-                                    .with_default(true);
+                                let acl_confirmation_prompt =
+                                    Confirm::new("Would you like to enable ACL?")
+                                        .with_placeholder("Y")
+                                        .with_default(true);
 
-                                if
-                                    let Some(acl_confirmation) =
-                                        prompt_user(acl_confirmation_prompt)
+                                if let Some(acl_confirmation) = prompt_user(acl_confirmation_prompt)
                                 {
                                     let sync_service = twilio
                                         .sync()
@@ -100,7 +90,8 @@ pub async fn choose_sync_resource(twilio: &Client) {
                                             reachability_webhooks_enabled: None,
                                             webhooks_from_rest_enabled: None,
                                             webhook_url: None,
-                                        }).await
+                                        })
+                                        .await
                                         .unwrap_or_else(|error| panic!("{}", error));
                                     sync_services.push(sync_service);
                                     selected_sync_service_index = Some(sync_services.len() - 1);
@@ -116,7 +107,7 @@ pub async fn choose_sync_resource(twilio: &Client) {
                                 .iter()
                                 .position(|sync_service| sync_service.sid == choice[1..35])
                                 .expect(
-                                    "Could not find Sync Service in existing Sync Service list"
+                                    "Could not find Sync Service in existing Sync Service list",
                                 );
 
                             selected_sync_service_index = Some(sync_service_position);
@@ -143,23 +134,23 @@ pub async fn choose_sync_resource(twilio: &Client) {
                     println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync Service?"
-                    )
-                        .with_placeholder("N")
-                        .with_default(false);
+                    let confirm_prompt =
+                        Confirm::new("Are you sure to wish to delete the Sync Service?")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Service...");
                         twilio
                             .sync()
                             .service(&selected_sync_service.sid)
-                            .delete().await
+                            .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_services.remove(
                             selected_sync_service_index.expect(
-                                "Could not find Sync Service in existing Sync Services list"
-                            )
+                                "Could not find Sync Service in existing Sync Services list",
+                            ),
                         );
                         println!("Sync Service deleted.");
                         println!();

--- a/twilly_cli/src/sync/documents.rs
+++ b/twilly_cli/src/sync/documents.rs
@@ -1,10 +1,10 @@
 use std::process;
 
-use inquire::{ validator::Validation, Confirm, Select, Text };
+use inquire::{validator::Validation, Confirm, Select, Text};
 use strum::IntoEnumIterator;
-use strum_macros::{ Display, EnumIter, EnumString };
-use twilly::{ sync::services::SyncService, Client, ErrorKind };
-use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{sync::services::SyncService, Client, ErrorKind};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
@@ -25,109 +25,89 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
         if let Some(action) = prompt_user_selection(action_selection_prompt) {
             match action {
                 Action::GetDocument => {
-                    let document_sid_prompt = Text::new(
-                        "Please provide a document SID (or unique name):"
-                    )
-                        .with_placeholder("ET...")
-                        .with_validator(|val: &str| {
-                            match val.starts_with("ET") {
+                    let document_sid_prompt =
+                        Text::new("Please provide a document SID (or unique name):")
+                            .with_placeholder("ET...")
+                            .with_validator(|val: &str| match val.starts_with("ET") {
                                 true => Ok(Validation::Valid),
-                                false =>
-                                    Ok(
-                                        Validation::Invalid(
-                                            "Document SID must start with ET".into()
-                                        )
-                                    ),
-                            }
-                        })
-                        .with_validator(|val: &str| {
-                            match val.len() {
+                                false => Ok(Validation::Invalid(
+                                    "Document SID must start with ET".into(),
+                                )),
+                            })
+                            .with_validator(|val: &str| match val.len() {
                                 34 => Ok(Validation::Valid),
-                                _ =>
-                                    Ok(
-                                        Validation::Invalid(
-                                            "Your SID should be 34 characters in length".into()
-                                        )
-                                    ),
-                            }
-                        });
+                                _ => Ok(Validation::Invalid(
+                                    "Your SID should be 34 characters in length".into(),
+                                )),
+                            });
 
                     if let Some(document_sid) = prompt_user(document_sid_prompt) {
-                        match
-                            twilio
-                                .sync()
-                                .service(&sync_service.sid)
-                                .document(&document_sid)
-                                .get().await
+                        match twilio
+                            .sync()
+                            .service(&sync_service.sid)
+                            .document(&document_sid)
+                            .get()
+                            .await
                         {
-                            Ok(document) =>
-                                loop {
-                                    if
-                                        let Some(action_choice) = get_action_choice_from_user(
-                                            vec![
-                                                String::from("List Details"),
-                                                String::from("Delete")
-                                            ],
-                                            "Select an action: "
-                                        )
-                                    {
-                                        match action_choice {
-                                            ActionChoice::Back => {
-                                                break;
+                            Ok(document) => loop {
+                                if let Some(action_choice) = get_action_choice_from_user(
+                                    vec![String::from("List Details"), String::from("Delete")],
+                                    "Select an action: ",
+                                ) {
+                                    match action_choice {
+                                        ActionChoice::Back => {
+                                            break;
+                                        }
+                                        ActionChoice::Exit => process::exit(0),
+                                        ActionChoice::Other(choice) => match choice.as_str() {
+                                            "List Details" => {
+                                                println!("{:#?}", document);
+                                                println!();
                                             }
-                                            ActionChoice::Exit => process::exit(0),
-                                            ActionChoice::Other(choice) =>
-                                                match choice.as_str() {
-                                                    "List Details" => {
-                                                        println!("{:#?}", document);
-                                                        println!();
-                                                    }
-                                                    "Delete" => {
-                                                        let confirm_prompt = Confirm::new(
-                                                            "Are you sure to wish to delete the Document?"
-                                                        )
-                                                            .with_placeholder("N")
-                                                            .with_default(false);
-                                                        let confirmation =
-                                                            prompt_user(confirm_prompt);
-                                                        if
-                                                            confirmation.is_some() &&
-                                                            confirmation.unwrap() == true
-                                                        {
-                                                            println!("Deleting Document...");
-                                                            twilio
-                                                                .sync()
-                                                                .service(&sync_service.sid)
-                                                                .document(&document_sid)
-                                                                .delete().await
-                                                                .unwrap_or_else(|error| {
-                                                                    panic!("{}", error)
-                                                                });
-                                                            println!("Document deleted.");
-                                                            println!();
-                                                            break;
-                                                        }
-                                                    }
-                                                    _ => println!("Unknown action '{}'", choice),
+                                            "Delete" => {
+                                                let confirm_prompt = Confirm::new(
+                                                    "Are you sure to wish to delete the Document?",
+                                                )
+                                                .with_placeholder("N")
+                                                .with_default(false);
+                                                let confirmation = prompt_user(confirm_prompt);
+                                                if confirmation.is_some()
+                                                    && confirmation.unwrap() == true
+                                                {
+                                                    println!("Deleting Document...");
+                                                    twilio
+                                                        .sync()
+                                                        .service(&sync_service.sid)
+                                                        .document(&document_sid)
+                                                        .delete()
+                                                        .await
+                                                        .unwrap_or_else(|error| {
+                                                            panic!("{}", error)
+                                                        });
+                                                    println!("Document deleted.");
+                                                    println!();
+                                                    break;
                                                 }
-                                        }
+                                            }
+                                            _ => println!("Unknown action '{}'", choice),
+                                        },
                                     }
                                 }
-                            Err(error) =>
-                                match error.kind {
-                                    ErrorKind::TwilioError(twilio_error) => {
-                                        if twilio_error.status == 404 {
-                                            println!(
-                                                "A Document with SID '{}' was not found.",
-                                                &document_sid
-                                            );
-                                            println!("");
-                                        } else {
-                                            panic!("{}", twilio_error);
-                                        }
+                            },
+                            Err(error) => match error.kind {
+                                ErrorKind::TwilioError(twilio_error) => {
+                                    if twilio_error.status == 404 {
+                                        println!(
+                                            "A Document with SID '{}' was not found.",
+                                            &document_sid
+                                        );
+                                        println!("");
+                                    } else {
+                                        panic!("{}", twilio_error);
                                     }
-                                    _ => panic!("{}", error),
                                 }
+                                _ => panic!("{}", error),
+                            },
                         }
                     }
                 }
@@ -137,7 +117,8 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                         .sync()
                         .service(&sync_service.sid)
                         .documents()
-                        .list().await
+                        .list()
+                        .await
                         .unwrap_or_else(|error| panic!("{}", error));
 
                     let number_of_documents = documents.len();
@@ -153,15 +134,13 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                             let selected_document = if let Some(index) = selected_document_index {
                                 &mut documents[index]
                             } else {
-                                if
-                                    let Some(action_choice) = get_action_choice_from_user(
-                                        documents
-                                            .iter()
-                                            .map(|doc| format!("({}) {}", doc.sid, doc.unique_name))
-                                            .collect::<Vec<String>>(),
-                                        "Documents: "
-                                    )
-                                {
+                                if let Some(action_choice) = get_action_choice_from_user(
+                                    documents
+                                        .iter()
+                                        .map(|doc| format!("({}) {}", doc.sid, doc.unique_name))
+                                        .collect::<Vec<String>>(),
+                                    "Documents: ",
+                                ) {
                                     match action_choice {
                                         ActionChoice::Back => {
                                             break;
@@ -184,57 +163,54 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                             };
 
                             loop {
-                                if
-                                    let Some(action_choice) = get_action_choice_from_user(
-                                        vec![String::from("List Details"), String::from("Delete")],
-                                        "Select an action: "
-                                    )
-                                {
+                                if let Some(action_choice) = get_action_choice_from_user(
+                                    vec![String::from("List Details"), String::from("Delete")],
+                                    "Select an action: ",
+                                ) {
                                     match action_choice {
                                         ActionChoice::Back => {
                                             selected_document_index = None;
                                             break;
                                         }
                                         ActionChoice::Exit => process::exit(0),
-                                        ActionChoice::Other(choice) =>
-                                            match choice.as_str() {
-                                                "List Details" => {
-                                                    println!("{:#?}", selected_document);
-                                                    println!();
-                                                }
-                                                "Delete" => {
-                                                    let confirm_prompt = Confirm::new(
-                                                        "Are you sure to wish to delete the Document?"
-                                                    )
-                                                        .with_placeholder("N")
-                                                        .with_default(false);
-                                                    let confirmation = prompt_user(confirm_prompt);
-                                                    if
-                                                        confirmation.is_some() &&
-                                                        confirmation.unwrap() == true
-                                                    {
-                                                        println!("Deleting Document...");
-                                                        twilio
-                                                            .sync()
-                                                            .service(&sync_service.sid)
-                                                            .document(&selected_document.sid)
-                                                            .delete().await
-                                                            .unwrap_or_else(|error| {
-                                                                panic!("{}", error)
-                                                            });
-                                                        documents.remove(
+                                        ActionChoice::Other(choice) => match choice.as_str() {
+                                            "List Details" => {
+                                                println!("{:#?}", selected_document);
+                                                println!();
+                                            }
+                                            "Delete" => {
+                                                let confirm_prompt = Confirm::new(
+                                                    "Are you sure to wish to delete the Document?",
+                                                )
+                                                .with_placeholder("N")
+                                                .with_default(false);
+                                                let confirmation = prompt_user(confirm_prompt);
+                                                if confirmation.is_some()
+                                                    && confirmation.unwrap() == true
+                                                {
+                                                    println!("Deleting Document...");
+                                                    twilio
+                                                        .sync()
+                                                        .service(&sync_service.sid)
+                                                        .document(&selected_document.sid)
+                                                        .delete()
+                                                        .await
+                                                        .unwrap_or_else(|error| {
+                                                            panic!("{}", error)
+                                                        });
+                                                    documents.remove(
                                                             selected_document_index.expect(
                                                                 "Could not fin document in existing documents list"
                                                             )
                                                         );
-                                                        selected_document_index = None;
-                                                        println!("Document deleted.");
-                                                        println!();
-                                                        break;
-                                                    }
+                                                    selected_document_index = None;
+                                                    println!("Document deleted.");
+                                                    println!();
+                                                    break;
                                                 }
-                                                _ => println!("Unknown action '{}'", choice),
                                             }
+                                            _ => println!("Unknown action '{}'", choice),
+                                        },
                                     }
                                 }
                             }

--- a/twilly_cli/src/sync/documents.rs
+++ b/twilly_cli/src/sync/documents.rs
@@ -1,10 +1,10 @@
 use std::process;
 
-use inquire::{validator::Validation, Confirm, Select, Text};
+use inquire::{ validator::Validation, Confirm, Select, Text };
 use strum::IntoEnumIterator;
-use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{sync::services::SyncService, Client, ErrorKind};
-use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+use strum_macros::{ Display, EnumIter, EnumString };
+use twilly::{ sync::services::SyncService, Client, ErrorKind };
+use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
@@ -25,85 +25,109 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
         if let Some(action) = prompt_user_selection(action_selection_prompt) {
             match action {
                 Action::GetDocument => {
-                    let document_sid_prompt =
-                        Text::new("Please provide a document SID (or unique name):")
-                            .with_placeholder("ET...")
-                            .with_validator(|val: &str| match val.starts_with("ET") {
+                    let document_sid_prompt = Text::new(
+                        "Please provide a document SID (or unique name):"
+                    )
+                        .with_placeholder("ET...")
+                        .with_validator(|val: &str| {
+                            match val.starts_with("ET") {
                                 true => Ok(Validation::Valid),
-                                false => Ok(Validation::Invalid(
-                                    "Document SID must start with ET".into(),
-                                )),
-                            })
-                            .with_validator(|val: &str| match val.len() {
+                                false =>
+                                    Ok(
+                                        Validation::Invalid(
+                                            "Document SID must start with ET".into()
+                                        )
+                                    ),
+                            }
+                        })
+                        .with_validator(|val: &str| {
+                            match val.len() {
                                 34 => Ok(Validation::Valid),
-                                _ => Ok(Validation::Invalid(
-                                    "Your SID should be 34 characters in length".into(),
-                                )),
-                            });
+                                _ =>
+                                    Ok(
+                                        Validation::Invalid(
+                                            "Your SID should be 34 characters in length".into()
+                                        )
+                                    ),
+                            }
+                        });
 
                     if let Some(document_sid) = prompt_user(document_sid_prompt) {
-                        match twilio
-                            .sync()
-                            .service(&sync_service.sid)
-                            .document(&document_sid)
-                            .get()
-                            .await
+                        match
+                            twilio
+                                .sync()
+                                .service(&sync_service.sid)
+                                .document(&document_sid)
+                                .get().await
                         {
-                            Ok(document) => loop {
-                                if let Some(action_choice) = get_action_choice_from_user(
-                                    vec![String::from("List Details"), String::from("Delete")],
-                                    "Select an action: ",
-                                ) {
-                                    match action_choice {
-                                        ActionChoice::Back => break,
-                                        ActionChoice::Exit => process::exit(0),
-                                        ActionChoice::Other(choice) => match choice.as_str() {
-                                            "List Details" => {
-                                                println!("{:#?}", document);
-                                                println!();
+                            Ok(document) =>
+                                loop {
+                                    if
+                                        let Some(action_choice) = get_action_choice_from_user(
+                                            vec![
+                                                String::from("List Details"),
+                                                String::from("Delete")
+                                            ],
+                                            "Select an action: "
+                                        )
+                                    {
+                                        match action_choice {
+                                            ActionChoice::Back => {
+                                                break;
                                             }
-                                            "Delete" => {
-                                                let confirm_prompt = Confirm::new(
-                                                "Are you sure to wish to delete the Document? (Yes / No)",
-                                            );
-                                                let confirmation = prompt_user(confirm_prompt);
-                                                if confirmation.is_some()
-                                                    && confirmation.unwrap() == true
-                                                {
-                                                    println!("Deleting Document...");
-                                                    twilio
-                                                        .sync()
-                                                        .service(&sync_service.sid)
-                                                        .document(&document_sid)
-                                                        .delete()
-                                                        .await
-                                                        .unwrap_or_else(|error| {
-                                                            panic!("{}", error)
-                                                        });
-                                                    println!("Document deleted.");
-                                                    println!();
-                                                    break;
+                                            ActionChoice::Exit => process::exit(0),
+                                            ActionChoice::Other(choice) =>
+                                                match choice.as_str() {
+                                                    "List Details" => {
+                                                        println!("{:#?}", document);
+                                                        println!();
+                                                    }
+                                                    "Delete" => {
+                                                        let confirm_prompt = Confirm::new(
+                                                            "Are you sure to wish to delete the Document?"
+                                                        )
+                                                            .with_placeholder("N")
+                                                            .with_default(false);
+                                                        let confirmation =
+                                                            prompt_user(confirm_prompt);
+                                                        if
+                                                            confirmation.is_some() &&
+                                                            confirmation.unwrap() == true
+                                                        {
+                                                            println!("Deleting Document...");
+                                                            twilio
+                                                                .sync()
+                                                                .service(&sync_service.sid)
+                                                                .document(&document_sid)
+                                                                .delete().await
+                                                                .unwrap_or_else(|error| {
+                                                                    panic!("{}", error)
+                                                                });
+                                                            println!("Document deleted.");
+                                                            println!();
+                                                            break;
+                                                        }
+                                                    }
+                                                    _ => println!("Unknown action '{}'", choice),
                                                 }
-                                            }
-                                            _ => println!("Unknown action '{}'", choice),
-                                        },
+                                        }
                                     }
                                 }
-                            },
-                            Err(error) => match error.kind {
-                                ErrorKind::TwilioError(twilio_error) => {
-                                    if twilio_error.status == 404 {
-                                        println!(
-                                            "A Document with SID '{}' was not found.",
-                                            &document_sid
-                                        );
-                                        println!("");
-                                    } else {
-                                        panic!("{}", twilio_error)
+                            Err(error) =>
+                                match error.kind {
+                                    ErrorKind::TwilioError(twilio_error) => {
+                                        if twilio_error.status == 404 {
+                                            println!(
+                                                "A Document with SID '{}' was not found.",
+                                                &document_sid
+                                            );
+                                            println!("");
+                                        } else {
+                                            panic!("{}", twilio_error);
+                                        }
                                     }
+                                    _ => panic!("{}", error),
                                 }
-                                _ => panic!("{}", error),
-                            },
                         }
                     }
                 }
@@ -113,8 +137,7 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                         .sync()
                         .service(&sync_service.sid)
                         .documents()
-                        .list()
-                        .await
+                        .list().await
                         .unwrap_or_else(|error| panic!("{}", error));
 
                     let number_of_documents = documents.len();
@@ -130,13 +153,15 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                             let selected_document = if let Some(index) = selected_document_index {
                                 &mut documents[index]
                             } else {
-                                if let Some(action_choice) = get_action_choice_from_user(
-                                    documents
-                                        .iter()
-                                        .map(|doc| format!("({}) {}", doc.sid, doc.unique_name))
-                                        .collect::<Vec<String>>(),
-                                    "Documents: ",
-                                ) {
+                                if
+                                    let Some(action_choice) = get_action_choice_from_user(
+                                        documents
+                                            .iter()
+                                            .map(|doc| format!("({}) {}", doc.sid, doc.unique_name))
+                                            .collect::<Vec<String>>(),
+                                        "Documents: "
+                                    )
+                                {
                                     match action_choice {
                                         ActionChoice::Back => {
                                             break;
@@ -144,9 +169,11 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                                         ActionChoice::Exit => process::exit(0),
                                         ActionChoice::Other(choice) => {
                                             let document_position = documents
-											.iter()
-											.position(|doc| doc.sid == choice[1..35])
-											.expect("Could not find document in existing documents list");
+                                                .iter()
+                                                .position(|doc| doc.sid == choice[1..35])
+                                                .expect(
+                                                    "Could not find document in existing documents list"
+                                                );
                                             selected_document_index = Some(document_position);
                                             &mut documents[document_position]
                                         }
@@ -157,55 +184,66 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                             };
 
                             loop {
-                                if let Some(action_choice) = get_action_choice_from_user(
-                                    vec![String::from("List Details"), String::from("Delete")],
-                                    "Select an action: ",
-                                ) {
+                                if
+                                    let Some(action_choice) = get_action_choice_from_user(
+                                        vec![String::from("List Details"), String::from("Delete")],
+                                        "Select an action: "
+                                    )
+                                {
                                     match action_choice {
                                         ActionChoice::Back => {
                                             selected_document_index = None;
                                             break;
                                         }
                                         ActionChoice::Exit => process::exit(0),
-                                        ActionChoice::Other(choice) => match choice.as_str() {
-                                            "List Details" => {
-                                                println!("{:#?}", selected_document);
-                                                println!();
-                                            }
-                                            "Delete" => {
-                                                let confirm_prompt = Confirm::new(
-                                                "Are you sure to wish to delete the Document? (Yes / No)",
-                                            );
-                                                let confirmation = prompt_user(confirm_prompt);
-                                                if confirmation.is_some()
-                                                    && confirmation.unwrap() == true
-                                                {
-                                                    println!("Deleting Document...");
-                                                    twilio
-                                                        .sync()
-                                                        .service(&sync_service.sid)
-                                                        .document(&selected_document.sid)
-                                                        .delete()
-                                                        .await
-                                                        .unwrap_or_else(|error| {
-                                                            panic!("{}", error)
-                                                        });
-                                                    documents.remove(selected_document_index.expect("Could not fin document in existing documents list"));
-                                                    selected_document_index = None;
-                                                    println!("Document deleted.");
+                                        ActionChoice::Other(choice) =>
+                                            match choice.as_str() {
+                                                "List Details" => {
+                                                    println!("{:#?}", selected_document);
                                                     println!();
-                                                    break;
                                                 }
+                                                "Delete" => {
+                                                    let confirm_prompt = Confirm::new(
+                                                        "Are you sure to wish to delete the Document?"
+                                                    )
+                                                        .with_placeholder("N")
+                                                        .with_default(false);
+                                                    let confirmation = prompt_user(confirm_prompt);
+                                                    if
+                                                        confirmation.is_some() &&
+                                                        confirmation.unwrap() == true
+                                                    {
+                                                        println!("Deleting Document...");
+                                                        twilio
+                                                            .sync()
+                                                            .service(&sync_service.sid)
+                                                            .document(&selected_document.sid)
+                                                            .delete().await
+                                                            .unwrap_or_else(|error| {
+                                                                panic!("{}", error)
+                                                            });
+                                                        documents.remove(
+                                                            selected_document_index.expect(
+                                                                "Could not fin document in existing documents list"
+                                                            )
+                                                        );
+                                                        selected_document_index = None;
+                                                        println!("Document deleted.");
+                                                        println!();
+                                                        break;
+                                                    }
+                                                }
+                                                _ => println!("Unknown action '{}'", choice),
                                             }
-                                            _ => println!("Unknown action '{}'", choice),
-                                        },
                                     }
                                 }
                             }
                         }
                     }
                 }
-                Action::Back => break,
+                Action::Back => {
+                    break;
+                }
                 Action::Exit => process::exit(0),
             }
         } else {

--- a/twilly_cli/src/sync/listitems.rs
+++ b/twilly_cli/src/sync/listitems.rs
@@ -1,13 +1,10 @@
 use std::process;
 
-use inquire::{Confirm, Select};
+use inquire::{ Confirm, Select };
 use strum::IntoEnumIterator;
-use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{
-    sync::{listitems::ListParams, lists::SyncList, services::SyncService},
-    Client,
-};
-use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+use strum_macros::{ Display, EnumIter, EnumString };
+use twilly::{ sync::{ listitems::ListParams, lists::SyncList, services::SyncService }, Client };
+use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
@@ -28,8 +25,7 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
             order: None,
             bounds: None,
             from: None,
-        })
-        .await
+        }).await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_list_items.len() == 0 {
@@ -44,13 +40,15 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
         let selected_sync_list_item = if let Some(index) = selected_sync_list_index {
             &mut sync_list_items[index]
         } else {
-            if let Some(action_choice) = get_action_choice_from_user(
-                sync_list_items
-                    .iter()
-                    .map(|list_item| format!("{}", list_item.index))
-                    .collect::<Vec<String>>(),
-                "Choose a Sync List item: ",
-            ) {
+            if
+                let Some(action_choice) = get_action_choice_from_user(
+                    sync_list_items
+                        .iter()
+                        .map(|list_item| format!("{}", list_item.index))
+                        .collect::<Vec<String>>(),
+                    "Choose a Sync List item: "
+                )
+            {
                 match action_choice {
                     ActionChoice::Back => {
                         break;
@@ -77,12 +75,14 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
             match resource {
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_list_item);
-                    println!()
+                    println!();
                 }
                 Action::Delete => {
                     let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync List item? (Yes / No)",
-                    );
+                        "Are you sure to wish to delete the Sync List item?"
+                    )
+                        .with_placeholder("N")
+                        .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map item...");
@@ -91,18 +91,21 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
                             .service(&sync_service.sid)
                             .list(&list.sid)
                             .listitem(&selected_sync_list_item.index)
-                            .delete()
-                            .await
+                            .delete().await
                             .unwrap_or_else(|error| panic!("{}", error));
-                        sync_list_items.remove(selected_sync_list_index.expect(
-                            "Could not find Sync List item in existing Sync List items list",
-                        ));
+                        sync_list_items.remove(
+                            selected_sync_list_index.expect(
+                                "Could not find Sync List item in existing Sync List items list"
+                            )
+                        );
                         println!("Sync List item deleted.");
                         println!();
                         break;
                     }
                 }
-                Action::Back => break,
+                Action::Back => {
+                    break;
+                }
                 Action::Exit => process::exit(0),
             }
         }

--- a/twilly_cli/src/sync/listitems.rs
+++ b/twilly_cli/src/sync/listitems.rs
@@ -1,10 +1,13 @@
 use std::process;
 
-use inquire::{ Confirm, Select };
+use inquire::{Confirm, Select};
 use strum::IntoEnumIterator;
-use strum_macros::{ Display, EnumIter, EnumString };
-use twilly::{ sync::{ listitems::ListParams, lists::SyncList, services::SyncService }, Client };
-use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{
+    sync::{listitems::ListParams, lists::SyncList, services::SyncService},
+    Client,
+};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
@@ -25,7 +28,8 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
             order: None,
             bounds: None,
             from: None,
-        }).await
+        })
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_list_items.len() == 0 {
@@ -40,15 +44,13 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
         let selected_sync_list_item = if let Some(index) = selected_sync_list_index {
             &mut sync_list_items[index]
         } else {
-            if
-                let Some(action_choice) = get_action_choice_from_user(
-                    sync_list_items
-                        .iter()
-                        .map(|list_item| format!("{}", list_item.index))
-                        .collect::<Vec<String>>(),
-                    "Choose a Sync List item: "
-                )
-            {
+            if let Some(action_choice) = get_action_choice_from_user(
+                sync_list_items
+                    .iter()
+                    .map(|list_item| format!("{}", list_item.index))
+                    .collect::<Vec<String>>(),
+                "Choose a Sync List item: ",
+            ) {
                 match action_choice {
                     ActionChoice::Back => {
                         break;
@@ -78,11 +80,10 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
                     println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync List item?"
-                    )
-                        .with_placeholder("N")
-                        .with_default(false);
+                    let confirm_prompt =
+                        Confirm::new("Are you sure to wish to delete the Sync List item?")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map item...");
@@ -91,13 +92,12 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
                             .service(&sync_service.sid)
                             .list(&list.sid)
                             .listitem(&selected_sync_list_item.index)
-                            .delete().await
+                            .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
-                        sync_list_items.remove(
-                            selected_sync_list_index.expect(
-                                "Could not find Sync List item in existing Sync List items list"
-                            )
-                        );
+                        sync_list_items.remove(selected_sync_list_index.expect(
+                            "Could not find Sync List item in existing Sync List items list",
+                        ));
                         println!("Sync List item deleted.");
                         println!();
                         break;

--- a/twilly_cli/src/sync/lists.rs
+++ b/twilly_cli/src/sync/lists.rs
@@ -1,10 +1,10 @@
 use std::process;
 
-use inquire::{Confirm, Select};
+use inquire::{ Confirm, Select };
 use strum::IntoEnumIterator;
-use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{sync::services::SyncService, Client};
-use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+use strum_macros::{ Display, EnumIter, EnumString };
+use twilly::{ sync::services::SyncService, Client };
+use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
 
 use crate::sync::listitems;
 
@@ -24,8 +24,7 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
         .sync()
         .service(&sync_service.sid)
         .lists()
-        .list()
-        .await
+        .list().await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_lists.len() == 0 {
@@ -40,13 +39,15 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
         let selected_sync_list = if let Some(index) = selected_sync_list_index {
             &mut sync_lists[index]
         } else {
-            if let Some(action_choice) = get_action_choice_from_user(
-                sync_lists
-                    .iter()
-                    .map(|list| format!("({}) {}", list.sid, list.unique_name))
-                    .collect::<Vec<String>>(),
-                "Choose a Sync List: ",
-            ) {
+            if
+                let Some(action_choice) = get_action_choice_from_user(
+                    sync_lists
+                        .iter()
+                        .map(|list| format!("({}) {}", list.sid, list.unique_name))
+                        .collect::<Vec<String>>(),
+                    "Choose a Sync List: "
+                )
+            {
                 match action_choice {
                     ActionChoice::Back => {
                         break;
@@ -72,17 +73,23 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
         if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
             match resource {
                 Action::ListItem => {
-                    listitems::choose_list_item_action(&twilio, sync_service, &selected_sync_list)
-                        .await
+                    listitems::choose_list_item_action(
+                        &twilio,
+                        sync_service,
+                        &selected_sync_list
+                    ).await;
                 }
 
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_list);
-                    println!()
+                    println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt =
-                        Confirm::new("Are you sure to wish to delete the Sync List? (Yes / No)");
+                    let confirm_prompt = Confirm::new(
+                        "Are you sure to wish to delete the Sync List?"
+                    )
+                        .with_placeholder("N")
+                        .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync List...");
@@ -90,19 +97,21 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
                             .sync()
                             .service(&sync_service.sid)
                             .list(&selected_sync_list.sid)
-                            .delete()
-                            .await
+                            .delete().await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_lists.remove(
-                            selected_sync_list_index
-                                .expect("Could not find Sync List in existing Sync Maps list"),
+                            selected_sync_list_index.expect(
+                                "Could not find Sync List in existing Sync Maps list"
+                            )
                         );
                         println!("Sync List deleted.");
                         println!();
                         break;
                     }
                 }
-                Action::Back => break,
+                Action::Back => {
+                    break;
+                }
                 Action::Exit => process::exit(0),
             }
         }

--- a/twilly_cli/src/sync/lists.rs
+++ b/twilly_cli/src/sync/lists.rs
@@ -1,10 +1,10 @@
 use std::process;
 
-use inquire::{ Confirm, Select };
+use inquire::{Confirm, Select};
 use strum::IntoEnumIterator;
-use strum_macros::{ Display, EnumIter, EnumString };
-use twilly::{ sync::services::SyncService, Client };
-use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{sync::services::SyncService, Client};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
 
 use crate::sync::listitems;
 
@@ -24,7 +24,8 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
         .sync()
         .service(&sync_service.sid)
         .lists()
-        .list().await
+        .list()
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_lists.len() == 0 {
@@ -39,15 +40,13 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
         let selected_sync_list = if let Some(index) = selected_sync_list_index {
             &mut sync_lists[index]
         } else {
-            if
-                let Some(action_choice) = get_action_choice_from_user(
-                    sync_lists
-                        .iter()
-                        .map(|list| format!("({}) {}", list.sid, list.unique_name))
-                        .collect::<Vec<String>>(),
-                    "Choose a Sync List: "
-                )
-            {
+            if let Some(action_choice) = get_action_choice_from_user(
+                sync_lists
+                    .iter()
+                    .map(|list| format!("({}) {}", list.sid, list.unique_name))
+                    .collect::<Vec<String>>(),
+                "Choose a Sync List: ",
+            ) {
                 match action_choice {
                     ActionChoice::Back => {
                         break;
@@ -73,11 +72,8 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
         if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
             match resource {
                 Action::ListItem => {
-                    listitems::choose_list_item_action(
-                        &twilio,
-                        sync_service,
-                        &selected_sync_list
-                    ).await;
+                    listitems::choose_list_item_action(&twilio, sync_service, &selected_sync_list)
+                        .await;
                 }
 
                 Action::ListDetails => {
@@ -85,11 +81,10 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
                     println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync List?"
-                    )
-                        .with_placeholder("N")
-                        .with_default(false);
+                    let confirm_prompt =
+                        Confirm::new("Are you sure to wish to delete the Sync List?")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync List...");
@@ -97,12 +92,12 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
                             .sync()
                             .service(&sync_service.sid)
                             .list(&selected_sync_list.sid)
-                            .delete().await
+                            .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_lists.remove(
-                            selected_sync_list_index.expect(
-                                "Could not find Sync List in existing Sync Maps list"
-                            )
+                            selected_sync_list_index
+                                .expect("Could not find Sync List in existing Sync Maps list"),
                         );
                         println!("Sync List deleted.");
                         println!();

--- a/twilly_cli/src/sync/mapitems.rs
+++ b/twilly_cli/src/sync/mapitems.rs
@@ -1,13 +1,10 @@
 use std::process;
 
-use inquire::{Confirm, Select};
+use inquire::{ Confirm, Select };
 use strum::IntoEnumIterator;
-use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{
-    sync::{mapitems::ListParams, maps::SyncMap, services::SyncService},
-    Client,
-};
-use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+use strum_macros::{ Display, EnumIter, EnumString };
+use twilly::{ sync::{ mapitems::ListParams, maps::SyncMap, services::SyncService }, Client };
+use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
@@ -28,8 +25,7 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
             order: None,
             bounds: None,
             from: None,
-        })
-        .await
+        }).await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_map_items.len() == 0 {
@@ -44,13 +40,15 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
         let selected_sync_map_item = if let Some(index) = selected_sync_map_index {
             &mut sync_map_items[index]
         } else {
-            if let Some(action_choice) = get_action_choice_from_user(
-                sync_map_items
-                    .iter()
-                    .map(|map_item| format!("{}", map_item.key))
-                    .collect::<Vec<String>>(),
-                "Choose a Sync Map item: ",
-            ) {
+            if
+                let Some(action_choice) = get_action_choice_from_user(
+                    sync_map_items
+                        .iter()
+                        .map(|map_item| format!("{}", map_item.key))
+                        .collect::<Vec<String>>(),
+                    "Choose a Sync Map item: "
+                )
+            {
                 match action_choice {
                     ActionChoice::Back => {
                         break;
@@ -77,12 +75,14 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
             match resource {
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_map_item);
-                    println!()
+                    println!();
                 }
                 Action::Delete => {
                     let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync Map item? (Yes / No)",
-                    );
+                        "Are you sure to wish to delete the Sync Map item?"
+                    )
+                        .with_placeholder("N")
+                        .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map item...");
@@ -91,18 +91,21 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
                             .service(&sync_service.sid)
                             .map(&map.sid)
                             .mapitem(&selected_sync_map_item.key)
-                            .delete()
-                            .await
+                            .delete().await
                             .unwrap_or_else(|error| panic!("{}", error));
-                        sync_map_items.remove(selected_sync_map_index.expect(
-                            "Could not find Sync Map item in existing Sync Map items list",
-                        ));
+                        sync_map_items.remove(
+                            selected_sync_map_index.expect(
+                                "Could not find Sync Map item in existing Sync Map items list"
+                            )
+                        );
                         println!("Sync Map item deleted.");
                         println!();
                         break;
                     }
                 }
-                Action::Back => break,
+                Action::Back => {
+                    break;
+                }
                 Action::Exit => process::exit(0),
             }
         }

--- a/twilly_cli/src/sync/mapitems.rs
+++ b/twilly_cli/src/sync/mapitems.rs
@@ -1,10 +1,13 @@
 use std::process;
 
-use inquire::{ Confirm, Select };
+use inquire::{Confirm, Select};
 use strum::IntoEnumIterator;
-use strum_macros::{ Display, EnumIter, EnumString };
-use twilly::{ sync::{ mapitems::ListParams, maps::SyncMap, services::SyncService }, Client };
-use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{
+    sync::{mapitems::ListParams, maps::SyncMap, services::SyncService},
+    Client,
+};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
@@ -25,7 +28,8 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
             order: None,
             bounds: None,
             from: None,
-        }).await
+        })
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_map_items.len() == 0 {
@@ -40,15 +44,13 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
         let selected_sync_map_item = if let Some(index) = selected_sync_map_index {
             &mut sync_map_items[index]
         } else {
-            if
-                let Some(action_choice) = get_action_choice_from_user(
-                    sync_map_items
-                        .iter()
-                        .map(|map_item| format!("{}", map_item.key))
-                        .collect::<Vec<String>>(),
-                    "Choose a Sync Map item: "
-                )
-            {
+            if let Some(action_choice) = get_action_choice_from_user(
+                sync_map_items
+                    .iter()
+                    .map(|map_item| format!("{}", map_item.key))
+                    .collect::<Vec<String>>(),
+                "Choose a Sync Map item: ",
+            ) {
                 match action_choice {
                     ActionChoice::Back => {
                         break;
@@ -78,11 +80,10 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
                     println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync Map item?"
-                    )
-                        .with_placeholder("N")
-                        .with_default(false);
+                    let confirm_prompt =
+                        Confirm::new("Are you sure to wish to delete the Sync Map item?")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map item...");
@@ -91,13 +92,12 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
                             .service(&sync_service.sid)
                             .map(&map.sid)
                             .mapitem(&selected_sync_map_item.key)
-                            .delete().await
+                            .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
-                        sync_map_items.remove(
-                            selected_sync_map_index.expect(
-                                "Could not find Sync Map item in existing Sync Map items list"
-                            )
-                        );
+                        sync_map_items.remove(selected_sync_map_index.expect(
+                            "Could not find Sync Map item in existing Sync Map items list",
+                        ));
                         println!("Sync Map item deleted.");
                         println!();
                         break;

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -1,10 +1,10 @@
 use std::process;
 
-use inquire::{ Confirm, Select };
+use inquire::{Confirm, Select};
 use strum::IntoEnumIterator;
-use strum_macros::{ Display, EnumIter, EnumString };
-use twilly::{ sync::services::SyncService, Client };
-use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{sync::services::SyncService, Client};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
 
 use crate::sync::mapitems;
 
@@ -24,7 +24,8 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
         .sync()
         .service(&sync_service.sid)
         .maps()
-        .list().await
+        .list()
+        .await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_maps.len() == 0 {
@@ -39,15 +40,13 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
         let selected_sync_map = if let Some(index) = selected_sync_map_index {
             &mut sync_maps[index]
         } else {
-            if
-                let Some(action_choice) = get_action_choice_from_user(
-                    sync_maps
-                        .iter()
-                        .map(|map| format!("({}) {}", map.sid, map.unique_name))
-                        .collect::<Vec<String>>(),
-                    "Choose a Sync Map: "
-                )
-            {
+            if let Some(action_choice) = get_action_choice_from_user(
+                sync_maps
+                    .iter()
+                    .map(|map| format!("({}) {}", map.sid, map.unique_name))
+                    .collect::<Vec<String>>(),
+                "Choose a Sync Map: ",
+            ) {
                 match action_choice {
                     ActionChoice::Back => {
                         break;
@@ -73,11 +72,8 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
         if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
             match resource {
                 Action::MapItem => {
-                    mapitems::choose_map_item_action(
-                        &twilio,
-                        sync_service,
-                        &selected_sync_map
-                    ).await;
+                    mapitems::choose_map_item_action(&twilio, sync_service, &selected_sync_map)
+                        .await;
                 }
 
                 Action::ListDetails => {
@@ -85,11 +81,10 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                     println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync Map?"
-                    )
-                        .with_placeholder("N")
-                        .with_default(false);
+                    let confirm_prompt =
+                        Confirm::new("Are you sure to wish to delete the Sync Map?")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map...");
@@ -97,12 +92,12 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                             .sync()
                             .service(&sync_service.sid)
                             .map(&selected_sync_map.sid)
-                            .delete().await
+                            .delete()
+                            .await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_maps.remove(
-                            selected_sync_map_index.expect(
-                                "Could not find Sync Map in existing Sync Maps list"
-                            )
+                            selected_sync_map_index
+                                .expect("Could not find Sync Map in existing Sync Maps list"),
                         );
                         println!("Sync Map deleted.");
                         println!();

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -1,10 +1,10 @@
 use std::process;
 
-use inquire::{Confirm, Select};
+use inquire::{ Confirm, Select };
 use strum::IntoEnumIterator;
-use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{sync::services::SyncService, Client};
-use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+use strum_macros::{ Display, EnumIter, EnumString };
+use twilly::{ sync::services::SyncService, Client };
+use twilly_cli::{ get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice };
 
 use crate::sync::mapitems;
 
@@ -24,8 +24,7 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
         .sync()
         .service(&sync_service.sid)
         .maps()
-        .list()
-        .await
+        .list().await
         .unwrap_or_else(|error| panic!("{}", error));
 
     if sync_maps.len() == 0 {
@@ -40,13 +39,15 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
         let selected_sync_map = if let Some(index) = selected_sync_map_index {
             &mut sync_maps[index]
         } else {
-            if let Some(action_choice) = get_action_choice_from_user(
-                sync_maps
-                    .iter()
-                    .map(|map| format!("({}) {}", map.sid, map.unique_name))
-                    .collect::<Vec<String>>(),
-                "Choose a Sync Map: ",
-            ) {
+            if
+                let Some(action_choice) = get_action_choice_from_user(
+                    sync_maps
+                        .iter()
+                        .map(|map| format!("({}) {}", map.sid, map.unique_name))
+                        .collect::<Vec<String>>(),
+                    "Choose a Sync Map: "
+                )
+            {
                 match action_choice {
                     ActionChoice::Back => {
                         break;
@@ -72,17 +73,23 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
         if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
             match resource {
                 Action::MapItem => {
-                    mapitems::choose_map_item_action(&twilio, sync_service, &selected_sync_map)
-                        .await
+                    mapitems::choose_map_item_action(
+                        &twilio,
+                        sync_service,
+                        &selected_sync_map
+                    ).await;
                 }
 
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_map);
-                    println!()
+                    println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt =
-                        Confirm::new("Are you sure to wish to delete the Sync Map? (Yes / No)");
+                    let confirm_prompt = Confirm::new(
+                        "Are you sure to wish to delete the Sync Map?"
+                    )
+                        .with_placeholder("N")
+                        .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map...");
@@ -90,19 +97,21 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                             .sync()
                             .service(&sync_service.sid)
                             .map(&selected_sync_map.sid)
-                            .delete()
-                            .await
+                            .delete().await
                             .unwrap_or_else(|error| panic!("{}", error));
                         sync_maps.remove(
-                            selected_sync_map_index
-                                .expect("Could not find Sync Map in existing Sync Maps list"),
+                            selected_sync_map_index.expect(
+                                "Could not find Sync Map in existing Sync Maps list"
+                            )
                         );
                         println!("Sync Map deleted.");
                         println!();
                         break;
                     }
                 }
-                Action::Back => break,
+                Action::Back => {
+                    break;
+                }
                 Action::Exit => process::exit(0),
             }
         }


### PR DESCRIPTION
Added `with_default` and `with_placeholder` to each `Confirm::new` setup.

For delete style operations, or operations with dangerous outcomes, the default is N / false.
For positive / timesaving operations, the default is Y / true.