### PR TITLE
Feature/participant conversations

### DIFF
--- a/twilly/src/conversation.rs
+++ b/twilly/src/conversation.rs
@@ -1,6 +1,6 @@
 /*!
 
-Contains Twilio conversations related functionality.
+Contains Twilio conversation related functionality.
 
 */
 use std::fmt;

--- a/twilly/src/conversation.rs
+++ b/twilly/src/conversation.rs
@@ -9,7 +9,7 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
 
-use crate::{Client, PageMeta, TwilioError};
+use crate::{participant_conversation::ParticipantConversations, Client, PageMeta, TwilioError};
 
 /// Holds conversation related functions accessible
 /// on the client.
@@ -253,5 +253,12 @@ impl<'a> Conversations<'a> {
             .await;
 
         conversation
+    }
+
+    /// Participant Conversation related functions.
+    pub fn participant_conversations<'b>(&'b self) -> ParticipantConversations {
+        ParticipantConversations {
+            client: &self.client,
+        }
     }
 }

--- a/twilly/src/lib.rs
+++ b/twilly/src/lib.rs
@@ -35,6 +35,7 @@ twilio.conversations().delete(&conversation_sid);
 
 pub mod account;
 pub mod conversation;
+pub mod participant_conversation;
 pub mod sync;
 
 use std::fmt::{self};

--- a/twilly/src/participant_conversation.rs
+++ b/twilly/src/participant_conversation.rs
@@ -90,12 +90,12 @@ impl<'a> ParticipantConversations<'a> {
     ) -> Result<Vec<ParticipantConversation>, TwilioError> {
         let params = ListParams {
             identity: if let Some(identity) = identity {
-                Some(identity.to_string())
+                Some(identity)
             } else {
                 None
             },
             address: if let Some(address) = address {
-                Some(address.to_string())
+                Some(address)
             } else {
                 None
             },

--- a/twilly/src/participant_conversation.rs
+++ b/twilly/src/participant_conversation.rs
@@ -32,9 +32,9 @@ pub struct ParticipantConversation {
     pub account_sid: String,
     pub chat_service_sid: String,
     pub participant_sid: String,
-    pub participant_user_sid: String,
-    pub participant_identity: String,
-    pub participant_messaging_binding: ParticipantMessagingBinding,
+    pub participant_user_sid: Option<String>,
+    pub participant_identity: Option<String>,
+    pub participant_messaging_binding: Option<ParticipantMessagingBinding>,
     pub conversation_sid: String,
     pub conversation_unique_name: Option<String>,
     pub conversation_friendly_name: Option<String>,
@@ -47,19 +47,20 @@ pub struct ParticipantConversation {
     pub links: Links,
 }
 
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 pub struct ParticipantMessagingBinding {
     pub address: String,
     pub proxy_address: String,
     #[serde(rename = "type")]
     pub type_field: String,
-    level: Option<String>,
-    name: Option<String>,
-    projected_address: Option<String>,
+    pub level: Option<String>,
+    pub name: Option<String>,
+    pub projected_address: Option<String>,
 }
 
 /// Resources _linked_ to a participants conversation. These can be used to retrieve
 /// sub resources directly.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq)]
 pub struct Links {
     pub participant: String,
     pub conversation: String,

--- a/twilly/src/participant_conversation.rs
+++ b/twilly/src/participant_conversation.rs
@@ -1,0 +1,132 @@
+/*!
+
+Contains Twilio participant conversation related functionality.
+
+*/
+
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    conversation::{State, Timers},
+    Client, PageMeta, TwilioError,
+};
+
+/// Holds participant conversation related functions accessible
+/// on the client.
+pub struct ParticipantConversations<'a> {
+    pub client: &'a Client,
+}
+
+/// Represents a page of participant conversations from the Twilio API.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+pub struct ParticipantConversationPage {
+    conversations: Vec<ParticipantConversation>,
+    meta: PageMeta,
+}
+
+/// Participant conversation details.
+#[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+pub struct ParticipantConversation {
+    pub account_sid: String,
+    pub chat_service_sid: String,
+    pub participant_sid: String,
+    pub participant_user_sid: String,
+    pub participant_identity: String,
+    pub participant_messaging_binding: ParticipantMessagingBinding,
+    pub conversation_sid: String,
+    pub conversation_unique_name: Option<String>,
+    pub conversation_friendly_name: Option<String>,
+    pub conversation_attributes: String,
+    pub conversation_date_created: String,
+    pub conversation_date_updated: String,
+    pub conversation_created_by: String,
+    pub conversation_state: State,
+    pub conversation_timers: Timers,
+    pub links: Links,
+}
+
+pub struct ParticipantMessagingBinding {
+    pub address: String,
+    pub proxy_address: String,
+    #[serde(rename = "type")]
+    pub type_field: String,
+    level: Option<String>,
+    name: Option<String>,
+    projected_address: Option<String>,
+}
+
+/// Resources _linked_ to a participants conversation. These can be used to retrieve
+/// sub resources directly.
+#[derive(Clone, Debug, Deserialize)]
+pub struct Links {
+    pub participant: String,
+    pub conversation: String,
+}
+
+/// Possible filters for listing participant conversations via the Twilio API
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+struct ListParams {
+    identity: Option<String>,
+    address: Option<String>,
+}
+
+impl<'a> ParticipantConversations<'a> {
+    /// [Lists Participant Conversations](https://www.twilio.com/docs/conversations/api/participant-conversation-resource#list-all-of-a-participants-conversations)
+    ///
+    /// This will eagerly fetch *all* conversations relating to a particular identity or address on the Twilio account.
+    ///
+    /// Takes optional parameters:
+    /// - `identity` - The identity used for the participant (used for participants using the Conversations SDK).
+    /// - `address` - Or the address the participant is communicating on. This typically links directly
+    /// to `messaging_binding.address` of a Conversation.
+    pub async fn list(
+        &self,
+        identity: Option<String>,
+        address: Option<String>,
+    ) -> Result<Vec<ParticipantConversation>, TwilioError> {
+        let params = ListParams {
+            identity: if let Some(identity) = identity {
+                Some(identity.to_string())
+            } else {
+                None
+            },
+            address: if let Some(address) = address {
+                Some(address.to_string())
+            } else {
+                None
+            },
+        };
+
+        let mut participant_conversations_page = self
+            .client
+            .send_request::<ParticipantConversationPage, ListParams>(
+                Method::GET,
+                "https://conversations.twilio.com/v1/ParticipantConversations",
+                Some(&params),
+                None,
+            )
+            .await?;
+
+        let mut results: Vec<ParticipantConversation> =
+            participant_conversations_page.conversations;
+
+        while (participant_conversations_page.meta.next_page_url).is_some() {
+            participant_conversations_page = self
+                .client
+                .send_request::<ParticipantConversationPage, ()>(
+                    Method::GET,
+                    &participant_conversations_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
+
+            results.append(&mut participant_conversations_page.conversations);
+        }
+
+        Ok(results)
+    }
+}

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -553,7 +553,7 @@ pub async fn choose_conversation_action(twilio: &Client) {
                 }
                 Action::DeleteAllConversations => {
                     let first_confirmation_prompt =
-                        Confirm::new("Are you sure you wish to delete **all** Conversations? ")
+                        Confirm::new("Are you sure you wish to delete **all** Conversations?")
                             .with_placeholder("N")
                             .with_default(false);
                     let second_confirmation_prompt =

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -19,6 +19,8 @@ pub enum Action {
     GetConversation,
     #[strum(to_string = "List Conversations")]
     ListConversations,
+    #[strum(to_string = "List Conversations by identifier")]
+    ListByIdentifier,
     #[strum(to_string = "Delete Conversation")]
     DeleteConversation,
     #[strum(to_string = "Delete all Conversations")]
@@ -437,6 +439,52 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                         },
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
+                Action::ListByIdentifier => {
+                    let identifier_selection =
+                        Select::new("Select an identifier:", vec!["Identity", "Address"]);
+
+                    if let Some(identifier) = prompt_user_selection(identifier_selection) {
+                        match identifier {
+                            "Identity" => {
+                                let identity_prompt =
+                                    Text::new("Please provide the identity to search for:");
+
+                                if let Some(identity) = prompt_user(identity_prompt) {
+                                    let conversations = twilio
+                                        .conversations()
+                                        .participant_conversations()
+                                        .list(Some(identity), None)
+                                        .await
+                                        .unwrap_or_else(|error| panic!("{}", error));
+
+                                    conversations
+                                        .into_iter()
+                                        .for_each(|conv| println!("{:#?}", conv.conversation_sid))
+                                }
+                            }
+                            "Address" => {
+                                let address_prompt =
+                                    Text::new("Please provide the address to search for:");
+
+                                if let Some(address) = prompt_user(address_prompt) {
+                                    let conversations = twilio
+                                        .conversations()
+                                        .participant_conversations()
+                                        .list(None, Some(address))
+                                        .await
+                                        .unwrap_or_else(|error| panic!("{}", error));
+
+                                    conversations
+                                        .into_iter()
+                                        .for_each(|conv| println!("{:#?}", conv.conversation_sid));
+                                }
+                            }
+                            _ => {
+                                println!("Unknown identifer '{}'", identifier)
                             }
                         }
                     }

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -552,11 +552,10 @@ pub async fn choose_conversation_action(twilio: &Client) {
                     }
                 }
                 Action::DeleteAllConversations => {
-                    let first_confirmation_prompt = Confirm::new(
-                        "Are you sure you wish to delete **all** Conversations? (Yes / No)",
-                    )
-                    .with_placeholder("N")
-                    .with_default(false);
+                    let first_confirmation_prompt =
+                        Confirm::new("Are you sure you wish to delete **all** Conversations? ")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let second_confirmation_prompt =
                         Confirm::new("Are you double sure? There is no going back.")
                             .with_placeholder("N")

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -600,7 +600,7 @@ async fn update_conversation(
 /// Prompts the user for confirmation before deleting the conversation with
 /// the SID provided. Will panic if the delete operation fails.
 async fn delete_conversation(twilio: &Client, sid: &str) {
-    let confirmation_prompt = Confirm::new("Are you sure to wish to delete the Conversation?")
+    let confirmation_prompt = Confirm::new("Are you sure you wish to delete the Conversation?")
         .with_placeholder("N")
         .with_default(false);
 

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -71,8 +71,10 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                             }
                                             "Delete" => {
                                                 let confirm_prompt = Confirm::new(
-                                                "Are you sure to wish to delete the Conversation? (Yes / No)",
-                                            );
+                                                        "Are you sure you to wish to delete the Conversation?"
+                                                    )
+                                                        .with_placeholder("N")
+                                                        .with_default(false);
                                                 let confirmation = prompt_user(confirm_prompt);
                                                 if confirmation.is_some()
                                                     && confirmation.unwrap() == true
@@ -511,7 +513,7 @@ pub async fn choose_conversation_action(twilio: &Client) {
                 }
                 Action::DeleteAllConversations => {
                     let first_confirmation_prompt = Confirm::new(
-                        "Are you sure to wish to delete **all** Conversations? (Yes / No)",
+                        "Are you sure you wish to delete **all** Conversations? (Yes / No)",
                     );
                     let second_confirmation_prompt =
                         Confirm::new("Are you double sure? There is no going back. (Yes / No)");
@@ -582,8 +584,9 @@ async fn update_conversation(
 /// Prompts the user for confirmation before deleting the conversation with
 /// the SID provided. Will panic if the delete operation fails.
 async fn delete_conversation(twilio: &Client, sid: &str) {
-    let confirmation_prompt =
-        Confirm::new("Are you sure to wish to delete the Conversation? (Yes / No)");
+    let confirmation_prompt = Confirm::new("Are you sure you wish to delete the Conversation?")
+        .with_placeholder("N")
+        .with_default(false);
 
     if let Some(confirmation) = prompt_user(confirmation_prompt) {
         if confirmation == true {

--- a/twilly_cli/src/sync.rs
+++ b/twilly_cli/src/sync.rs
@@ -132,8 +132,9 @@ pub async fn choose_sync_resource(twilio: &Client) {
                     println!()
                 }
                 Action::Delete => {
-                    let confirm_prompt =
-                        Confirm::new("Are you sure to wish to delete the Sync Service? (Yes / No)");
+                    let confirm_prompt = Confirm::new(
+                        "Are you sure you wish to delete the Sync Service? (Yes / No)",
+                    );
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Service...");

--- a/twilly_cli/src/sync.rs
+++ b/twilly_cli/src/sync.rs
@@ -135,7 +135,7 @@ pub async fn choose_sync_resource(twilio: &Client) {
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure you wish to delete the Sync Service? ")
+                        Confirm::new("Are you sure you wish to delete the Sync Service?")
                             .with_placeholder("N")
                             .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);

--- a/twilly_cli/src/sync.rs
+++ b/twilly_cli/src/sync.rs
@@ -134,11 +134,10 @@ pub async fn choose_sync_resource(twilio: &Client) {
                     println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt = Confirm::new(
-                        "Are you sure you wish to delete the Sync Service? (Yes / No)",
-                    )
-                    .with_placeholder("N")
-                    .with_default(false);
+                    let confirm_prompt =
+                        Confirm::new("Are you sure you wish to delete the Sync Service? ")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Service...");

--- a/twilly_cli/src/sync/documents.rs
+++ b/twilly_cli/src/sync/documents.rs
@@ -66,8 +66,8 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                                             }
                                             "Delete" => {
                                                 let confirm_prompt = Confirm::new(
-                                                "Are you sure you wish to delete the Document? ",
-                                            )
+                                                    "Are you sure you wish to delete the Document?",
+                                                )
                                                 .with_placeholder("N")
                                                 .with_default(false);
                                                 let confirmation = prompt_user(confirm_prompt);

--- a/twilly_cli/src/sync/documents.rs
+++ b/twilly_cli/src/sync/documents.rs
@@ -64,7 +64,7 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                                             }
                                             "Delete" => {
                                                 let confirm_prompt = Confirm::new(
-                                                "Are you sure to wish to delete the Document? (Yes / No)",
+                                                "Are you sure you wish to delete the Document? (Yes / No)",
                                             );
                                                 let confirmation = prompt_user(confirm_prompt);
                                                 if confirmation.is_some()
@@ -174,7 +174,7 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                                             }
                                             "Delete" => {
                                                 let confirm_prompt = Confirm::new(
-                                                "Are you sure to wish to delete the Document? (Yes / No)",
+                                                "Are you sure you wish to delete the Document? (Yes / No)",
                                             );
                                                 let confirmation = prompt_user(confirm_prompt);
                                                 if confirmation.is_some()
@@ -190,7 +190,11 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                                                         .unwrap_or_else(|error| {
                                                             panic!("{}", error)
                                                         });
-                                                    documents.remove(selected_document_index.expect("Could not fin document in existing documents list"));
+                                                    documents.remove(
+                                                            selected_document_index.expect(
+                                                                "Could not find document in existing documents list"
+                                                            )
+                                                        );
                                                     selected_document_index = None;
                                                     println!("Document deleted.");
                                                     println!();

--- a/twilly_cli/src/sync/documents.rs
+++ b/twilly_cli/src/sync/documents.rs
@@ -66,7 +66,7 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                                             }
                                             "Delete" => {
                                                 let confirm_prompt = Confirm::new(
-                                                "Are you sure you wish to delete the Document? (Yes / No)",
+                                                "Are you sure you wish to delete the Document? ",
                                             )
                                                 .with_placeholder("N")
                                                 .with_default(false);
@@ -180,7 +180,7 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                                             }
                                             "Delete" => {
                                                 let confirm_prompt = Confirm::new(
-                                                "Are you sure you wish to delete the Document? (Yes / No)",
+                                                "Are you sure you wish to delete the Document? ",
                                             )
                                                 .with_placeholder("N")
                                                 .with_default(false);

--- a/twilly_cli/src/sync/listitems.rs
+++ b/twilly_cli/src/sync/listitems.rs
@@ -81,7 +81,7 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure you wish to delete the Sync List item? ")
+                        Confirm::new("Are you sure you wish to delete the Sync List item?")
                             .with_placeholder("N")
                             .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);

--- a/twilly_cli/src/sync/listitems.rs
+++ b/twilly_cli/src/sync/listitems.rs
@@ -81,7 +81,7 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
                 }
                 Action::Delete => {
                     let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync List item? (Yes / No)",
+                        "Are you sure you wish to delete the Sync List item? (Yes / No)",
                     );
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {

--- a/twilly_cli/src/sync/listitems.rs
+++ b/twilly_cli/src/sync/listitems.rs
@@ -80,11 +80,10 @@ pub async fn choose_list_item_action(twilio: &Client, sync_service: &SyncService
                     println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt = Confirm::new(
-                        "Are you sure you wish to delete the Sync List item? (Yes / No)",
-                    )
-                    .with_placeholder("N")
-                    .with_default(false);
+                    let confirm_prompt =
+                        Confirm::new("Are you sure you wish to delete the Sync List item? ")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map item...");

--- a/twilly_cli/src/sync/lists.rs
+++ b/twilly_cli/src/sync/lists.rs
@@ -82,7 +82,7 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure you wish to delete the Sync List? (Yes / No)")
+                        Confirm::new("Are you sure you wish to delete the Sync List? ")
                             .with_placeholder("N")
                             .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);

--- a/twilly_cli/src/sync/lists.rs
+++ b/twilly_cli/src/sync/lists.rs
@@ -82,7 +82,7 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure to wish to delete the Sync List? (Yes / No)");
+                        Confirm::new("Are you sure you wish to delete the Sync List? (Yes / No)");
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync List...");

--- a/twilly_cli/src/sync/lists.rs
+++ b/twilly_cli/src/sync/lists.rs
@@ -82,7 +82,7 @@ pub async fn choose_list_action(twilio: &Client, sync_service: &SyncService) {
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure you wish to delete the Sync List? ")
+                        Confirm::new("Are you sure you wish to delete the Sync List?")
                             .with_placeholder("N")
                             .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);

--- a/twilly_cli/src/sync/mapitems.rs
+++ b/twilly_cli/src/sync/mapitems.rs
@@ -81,7 +81,7 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure you wish to delete the Sync Map item? ")
+                        Confirm::new("Are you sure you wish to delete the Sync Map item?")
                             .with_placeholder("N")
                             .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);

--- a/twilly_cli/src/sync/mapitems.rs
+++ b/twilly_cli/src/sync/mapitems.rs
@@ -80,11 +80,10 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
                     println!();
                 }
                 Action::Delete => {
-                    let confirm_prompt = Confirm::new(
-                        "Are you sure you wish to delete the Sync Map item? (Yes / No)",
-                    )
-                    .with_placeholder("N")
-                    .with_default(false);
+                    let confirm_prompt =
+                        Confirm::new("Are you sure you wish to delete the Sync Map item? ")
+                            .with_placeholder("N")
+                            .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map item...");

--- a/twilly_cli/src/sync/mapitems.rs
+++ b/twilly_cli/src/sync/mapitems.rs
@@ -81,7 +81,7 @@ pub async fn choose_map_item_action(twilio: &Client, sync_service: &SyncService,
                 }
                 Action::Delete => {
                     let confirm_prompt = Confirm::new(
-                        "Are you sure to wish to delete the Sync Map item? (Yes / No)",
+                        "Are you sure you wish to delete the Sync Map item? (Yes / No)",
                     );
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -82,7 +82,7 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure you wish to delete the Sync Map? ")
+                        Confirm::new("Are you sure you wish to delete the Sync Map?")
                             .with_placeholder("N")
                             .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -82,7 +82,7 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure to wish to delete the Sync Map? (Yes / No)");
+                        Confirm::new("Are you sure you wish to delete the Sync Map? (Yes / No)");
                     let confirmation = prompt_user(confirm_prompt);
                     if confirmation.is_some() && confirmation.unwrap() == true {
                         println!("Deleting Sync Map...");

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -82,7 +82,7 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                 }
                 Action::Delete => {
                     let confirm_prompt =
-                        Confirm::new("Are you sure you wish to delete the Sync Map? (Yes / No)")
+                        Confirm::new("Are you sure you wish to delete the Sync Map? ")
                             .with_placeholder("N")
                             .with_default(false);
                     let confirmation = prompt_user(confirm_prompt);


### PR DESCRIPTION
Adds support for the [Conversation Participant](https://www.twilio.com/docs/conversations/api/conversation-participant-resource) resource to Twilly as well as extending the CLI to include an option that lets you search for conversations with an address/identity