### PR TITLE
feat: implement map renaming action

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "cSpell.words": ["chrono", "confy"]
+  "cSpell.words": ["chrono", "confy"],
+  "editor.rulers": [120]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +864,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
 name = "reqwest"
 version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1410,7 @@ dependencies = [
  "confy",
  "inquire",
  "openssl",
+ "regex",
  "strum",
  "strum_macros",
  "tokio",

--- a/twilly_cli/Cargo.toml
+++ b/twilly_cli/Cargo.toml
@@ -23,3 +23,4 @@ strum_macros = "0.26.1"
 confy = "0.6.0"
 openssl = { version = "0.10", features = ["vendored"] }
 tokio = { version = "1.37.0", features = ["macros", "time"] }
+regex = { version = "1.10.4" }

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -121,8 +121,11 @@ This process is non-reversible. We will:
     5. Create a new map with your new name
     6. Copy all items from the temporary map into the new map
 
+💡 Please note the TTL will not be preserved for the Map or items.
+
 We will not delete the temporary map after the process has completed.
 You can remove this using the CLI after you've confirmed the rename was successful.
+
 Would you like to continue?";
                     let confirm_operation = Confirm::new(confirmation_message)
                         .with_placeholder("N")
@@ -130,8 +133,10 @@ Would you like to continue?";
 
                     let confirmation_result = prompt_user(confirm_operation);
 
-                    if let None = confirmation_result {
-                        break;
+                    match confirmation_result {
+                        None => return,
+                        Some(false) => return,
+                        _ => (),
                     }
 
                     println!("Starting map rename process");
@@ -206,9 +211,16 @@ Would you like to continue?";
                     .with_default(false);
                     let confirm_copy = prompt_user(confirm_copy_message);
 
-                    if let None = confirm_copy {
-                        println!("Canceling operation. Copy was not successful.");
-                        return;
+                    match confirm_copy {
+                        None => {
+                            println!("Canceling operation. Copy was not successful.");
+                            return;
+                        }
+                        Some(false) => {
+                            println!("Canceling operation. Copy was not successful.");
+                            return;
+                        }
+                        _ => (),
                     }
 
                     // delete original map

--- a/twilly_cli/src/sync/maps.rs
+++ b/twilly_cli/src/sync/maps.rs
@@ -1,9 +1,17 @@
 use std::process;
 
-use inquire::{Confirm, Select};
+use inquire::{Confirm, Select, Text};
+use regex::Regex;
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
-use twilly::{sync::services::SyncService, Client};
+use twilly::{
+    sync::{
+        mapitems::{CreateParams as CreateMapItemParams, ListParams},
+        maps::CreateParams as CreateMapParams,
+        services::SyncService,
+    },
+    Client,
+};
 use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
 
 use crate::sync::mapitems;
@@ -14,6 +22,7 @@ pub enum Action {
     MapItem,
     #[strum(to_string = "List Details")]
     ListDetails,
+    Rename,
     Delete,
     Back,
     Exit,
@@ -79,6 +88,187 @@ pub async fn choose_map_action(twilio: &Client, sync_service: &SyncService) {
                 Action::ListDetails => {
                     println!("{:#?}", selected_sync_map);
                     println!();
+                }
+                Action::Rename => {
+                    let get_name_prompt = Text::new(
+                        "What would you like to rename this map to? Must be supported characters '^[a-zA-Z0-9-_]+$'"
+                    );
+                    let get_name_result = prompt_user(get_name_prompt);
+
+                    if let None = get_name_result {
+                        break;
+                    }
+
+                    let allowed_chars = Regex::new(r"^[a-zA-Z0-9-_]+$").unwrap();
+                    let name = get_name_result.unwrap();
+                    let trimmed_name = name.trim();
+                    if !allowed_chars.is_match(trimmed_name) {
+                        println!("Name doesn't match required filter '^[a-zA-Z0-9-_]+$'");
+                        break;
+                    }
+
+                    println!("Name confirmed '{trimmed_name}'");
+
+                    let confirmation_message = "⚠️ Warning ⚠️
+
+This process is non-reversible. We will:
+    1. Create a temporary map to hold a copy of the map items
+    2. Copy the items into the temporary map
+    3. Confirm the copy worked
+    4. Delete the original map
+    5. Create a new map with your new name
+    6. Copy all items from the temporary map into the new map
+
+We will not delete the temporary map after the process has completed.
+You can remove this using the CLI after you've confirmed the rename was successful.
+Would you like to continue?";
+                    let confirm_operation = Confirm::new(confirmation_message)
+                        .with_placeholder("N")
+                        .with_default(false);
+
+                    let confirmation_result = prompt_user(confirm_operation);
+
+                    if let None = confirmation_result {
+                        break;
+                    }
+
+                    println!("Starting map rename process");
+
+                    // create temporary map
+                    println!("(1/6) Creating temporary map");
+                    let temp_map_result = twilio
+                        .sync()
+                        .service(&sync_service.sid)
+                        .maps()
+                        .create(CreateMapParams {
+                            ttl: None,
+                            unique_name: Some(String::from(format!(
+                                "temp-{}",
+                                selected_sync_map.unique_name
+                            ))),
+                        })
+                        .await;
+
+                    if let Err(error) = temp_map_result {
+                        println!("Errored: Failed to create map: {:?}", error);
+                        break;
+                    }
+
+                    let temp_map = temp_map_result.unwrap();
+
+                    // clone all items into temp map
+                    println!("(2/6) Clone items into temporary map");
+                    let fetch_items_result = twilio
+                        .sync()
+                        .service(&sync_service.sid)
+                        .map(&selected_sync_map.sid)
+                        .mapitems()
+                        .list(ListParams {
+                            bounds: None,
+                            from: None,
+                            order: None,
+                        })
+                        .await;
+
+                    if let Err(error) = fetch_items_result {
+                        println!("Errored: Failed to fetch current map items: {:?}", error);
+                        break;
+                    }
+
+                    let items = fetch_items_result.unwrap();
+
+                    for item in items.iter() {
+                        let create_item_result = twilio
+                            .sync()
+                            .service(&sync_service.sid)
+                            .map(&temp_map.sid)
+                            .mapitems()
+                            .create(CreateMapItemParams {
+                                key: String::from(&item.key),
+                                data: &item.data,
+                                collection_ttl: None,
+                                ttl: None,
+                            })
+                            .await;
+
+                        if let Err(error) = create_item_result {
+                            println!("Errored: Failed while taking copy of items: {:?}", error);
+                            return;
+                        }
+                    }
+
+                    // confirm copy
+                    println!("(3/6) Confirm copy was successful");
+                    let confirm_copy_message = Confirm::new("Copy completed. Please confirm the temporary map created correctly to continue.")
+                    .with_placeholder("N")
+                    .with_default(false);
+                    let confirm_copy = prompt_user(confirm_copy_message);
+
+                    if let None = confirm_copy {
+                        println!("Canceling operation. Copy was not successful.");
+                        return;
+                    }
+
+                    // delete original map
+                    println!("(4/6) Delete original map");
+                    let _ = twilio
+                        .sync()
+                        .service(&sync_service.sid)
+                        .map(&selected_sync_map.sid)
+                        .delete()
+                        .await
+                        .unwrap_or_else(|error| panic!("{}", error));
+                    sync_maps.remove(
+                        selected_sync_map_index
+                            .expect("Could not find Sync Map in existing Sync Maps list"),
+                    );
+
+                    // create new map
+                    println!("(5/6) Create new map");
+                    let create_map_result = twilio
+                        .sync()
+                        .service(&sync_service.sid)
+                        .maps()
+                        .create(CreateMapParams {
+                            ttl: None,
+                            unique_name: Some(String::from(trimmed_name)),
+                        })
+                        .await;
+
+                    if let Err(error) = create_map_result {
+                        println!("Errored: Failed while creating new map: {:?}", error);
+                        break;
+                    }
+
+                    let new_map = create_map_result.unwrap();
+
+                    // clone all items into new map
+                    println!("(6/6) Clone items into new map");
+                    for item in items.iter() {
+                        let create_item_result = twilio
+                            .sync()
+                            .service(&sync_service.sid)
+                            .map(&new_map.sid)
+                            .mapitems()
+                            .create(CreateMapItemParams {
+                                key: String::from(&item.key),
+                                data: &item.data,
+                                collection_ttl: None,
+                                ttl: None,
+                            })
+                            .await;
+
+                        if let Err(error) = create_item_result {
+                            println!(
+                                "Errored: Failed while copying items to new map: {:?}",
+                                error
+                            );
+                            return;
+                        }
+                    }
+
+                    println!("Map rename complete");
+                    break;
                 }
                 Action::Delete => {
                     let confirm_prompt =


### PR DESCRIPTION
Implemented a map renaming process which:

    1. Create a temporary map to hold a copy of the map items
    2. Copy the items into the temporary map
    3. Confirm the copy worked
    4. Delete the original map
    5. Create a new map with your new name
    6. Copy all items from the temporary map into the new map