### PR TITLE
Feature: Serverless logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twilly"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "openssl",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "twilly_cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "confy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,18 +827,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1001,18 +1001,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,11 +1021,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1162,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1411,6 +1412,7 @@ dependencies = [
  "inquire",
  "openssl",
  "regex",
+ "serde_json",
  "strum",
  "strum_macros",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ cargo r
 
 ```sh
 # Download the packaged binary
-wget -q https://github.com/TristanBlackwell/twilly/releases/download/v0.1.1/twilly_cli-v0.1.1-x86_64-unknown-linux-musl.tar.gz
+wget -q https://github.com/TristanBlackwell/twilly/releases/download/v0.1.1/twilly_cli-v0.2.0-x86_64-unknown-linux-musl.tar.gz
 
 # Unpack
-tar xf twilly_cli-v0.1.1-x86_64-unknown-linux-musl.tar.gz
+tar xf twilly_cli-v0.2.0-x86_64-unknown-linux-musl.tar.gz
 
 # Move twilly_cli to system path
-mv twilly_cli-v0.1.1-x86_64-unknown-linux-musl/twilly_cli /usr/local/bin
+mv twilly_cli-v0.2.0-x86_64-unknown-linux-musl/twilly_cli /usr/local/bin
 
 # Cleanup
-rm -r twilly_cli-v0.1.1-x86_64-unknown-linux-musl twilly_cli-v0.1.1-x86_64-unknown-linux-musl.tar.gz
+rm -r twilly_cli-v0.2.0-x86_64-unknown-linux-musl twilly_cli-v0.2.0-x86_64-unknown-linux-musl.tar.gz
 
 # Run it
 twilly_cli
@@ -66,13 +66,13 @@ twilly_cli
 
 ```sh
 # Download the binary
-wget -q https://github.com/TristanBlackwell/twilly/releases/download/v0.1.1/twilly_cli-v0.1.1-x86_64-apple-darwin.tar.gz
+wget -q https://github.com/TristanBlackwell/twilly/releases/download/v0.2.0/twilly_cli-v0.2.0-x86_64-apple-darwin.tar.gz
 
-tar xf twilly_cli-v0.1.1-x86_64-apple-darwin.tar.gz
+tar xf twilly_cli-v0.2.0-x86_64-apple-darwin.tar.gz
 
-mv twilly_cli-v0.1.1-x86_64-apple-darwin/twilly_cli /usr/local/bin
+mv twilly_cli-v0.2.0-x86_64-apple-darwin/twilly_cli /usr/local/bin
 
-rm -r twilly_cli-v0.1.1-x86_64-apple-darwin twilly_cli-v0.1.1-x86_64-apple-darwin.tar.gz
+rm -r twilly_cli-v0.2.0-x86_64-apple-darwin twilly_cli-v0.2.0-x86_64-apple-darwin.tar.gz
 
 twilly_cli
 ```

--- a/twilly/Cargo.toml
+++ b/twilly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twilly"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "A implementation of the Twilio API in Rust built upon Reqwest and Serde"
 authors = ["Tristan Blackwell"]

--- a/twilly/src/lib.rs
+++ b/twilly/src/lib.rs
@@ -36,6 +36,7 @@ twilio.conversations().delete(&conversation_sid);
 pub mod account;
 pub mod conversation;
 pub mod participant_conversation;
+pub mod serverless;
 pub mod sync;
 
 use std::fmt::{self};

--- a/twilly/src/lib.rs
+++ b/twilly/src/lib.rs
@@ -45,6 +45,7 @@ use account::Accounts;
 use conversation::Conversations;
 use reqwest::{header::HeaderMap, Method, Response};
 use serde::{Deserialize, Serialize};
+use serverless::Serverless;
 use strum_macros::{Display, EnumIter, EnumString};
 use sync::Sync;
 
@@ -172,6 +173,7 @@ pub enum SubResource {
     Account,
     Conversations,
     Sync,
+    Serverless,
 }
 
 impl Client {
@@ -310,6 +312,10 @@ impl Client {
     /// Sync related functions.
     pub fn sync(&self) -> Sync {
         Sync { client: self }
+    }
+
+    pub fn serverless(&self) -> Serverless {
+        Serverless { client: self }
     }
 }
 

--- a/twilly/src/participant_conversation.rs
+++ b/twilly/src/participant_conversation.rs
@@ -81,8 +81,7 @@ impl<'a> ParticipantConversations<'a> {
     ///
     /// Takes optional parameters:
     /// - `identity` - The identity used for the participant (used for participants using the Conversations SDK).
-    /// - `address` - Or the address the participant is communicating on. This typically links directly
-    /// to `messaging_binding.address` of a Conversation.
+    /// - `address` - Or the address the participant is communicating on. This typically links directly to `messaging_binding.address` of a Conversation.
     pub async fn list(
         &self,
         identity: Option<String>,

--- a/twilly/src/serverless.rs
+++ b/twilly/src/serverless.rs
@@ -1,0 +1,36 @@
+/*!
+
+Contains Twilio Serverless related functionality.
+
+*/
+pub mod environments;
+pub mod services;
+
+use crate::Client;
+
+use self::services::{Service, Services};
+
+/// Holds Serverless related functions accessible
+/// on the client.
+pub struct Serverless<'a> {
+    pub client: &'a Client,
+}
+
+impl<'a> Serverless<'a> {
+    /// Actions relating to a known Function Service.
+    ///
+    /// Takes in the SID of the Service to perform actions against.
+    pub fn service<'b: 'a>(&'a self, sid: &'b str) -> Service {
+        Service {
+            client: self.client,
+            sid,
+        }
+    }
+
+    /// General Function Service actions.
+    pub fn services(&'a self) -> Services {
+        Services {
+            client: self.client,
+        }
+    }
+}

--- a/twilly/src/serverless/environments.rs
+++ b/twilly/src/serverless/environments.rs
@@ -7,6 +7,7 @@ Contains Twilio Serverless Environment related functionality.
 pub mod logs;
 
 use crate::{Client, PageMeta, TwilioError};
+use logs::{Log, Logs};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -28,7 +29,7 @@ pub struct ServerlessEnvironment {
     pub build_sid: String,
     pub unique_name: String,
     /// URL-friendly name which forms part of the domain (unless production).
-    pub domain_suffix: String,
+    pub domain_suffix: Option<String>,
     /// Domain for all functions & assets deployed in the Environment.
     pub domain_name: String,
     pub url: String,
@@ -164,5 +165,26 @@ impl<'a, 'b> Environment<'a, 'b> {
                 None,
             )
             .await
+    }
+
+    /// Functions relating to a known Environment Log.
+    ///
+    /// Takes in the key of the Sync List Item to perform actions against.
+    pub fn log(&'a self, sid: &'b str) -> Log {
+        Log {
+            client: self.client,
+            service_sid: self.service_sid,
+            environment_sid: self.sid,
+            sid,
+        }
+    }
+
+    /// General Sync Map Item functions.
+    pub fn logs(&'a self) -> Logs {
+        Logs {
+            client: self.client,
+            service_sid: self.service_sid,
+            environment_sid: self.sid,
+        }
     }
 }

--- a/twilly/src/serverless/environments.rs
+++ b/twilly/src/serverless/environments.rs
@@ -1,0 +1,246 @@
+/*!
+
+Contains Twilio Serverless Environment related functionality.
+
+*/
+
+use crate::{Client, PageMeta, TwilioError};
+use reqwest::{header::HeaderMap, Method};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use serde_with::skip_serializing_none;
+
+/// Represents a page of Serverless Environments from the Twilio API.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+pub struct EnvironmentPage {
+    environments: Vec<Environment>,
+    meta: PageMeta,
+}
+
+/// A Serverless Environment resource.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Environment {
+    pub sid: String,
+    pub account_sid: String,
+    pub service_sid: String,
+    pub build_sid: String,
+    pub unique_name: String,
+    /// URL-friendly name which forms part of the domain (unless production).
+    pub domain_suffix: String,
+    /// Domain for all functions & assets deployed in the Environment.
+    pub domain_name: String,
+    pub url: String,
+    pub date_created: String,
+    pub date_updated: String,
+}
+
+/// Resources _linked_ to a environment
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct Links {
+    pub variables: String,
+    pub deployments: String,
+    logs: String,
+}
+
+/// Parameters for creating an Environment
+pub struct CreateParams<'a, T>
+where
+    T: ?Sized + Serialize,
+{
+    pub unique_name: Option<String>,
+    pub data: &'a T,
+    /// How long the Document should exist before deletion (in seconds).
+    pub ttl: Option<u16>,
+}
+
+/// Parameters for creating a Sync Document with
+/// data converted to a JSON string
+#[skip_serializing_none]
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+struct CreateParamsWithJson {
+    unique_name: Option<String>,
+    data: String,
+    /// How long the Document should exist before deletion (in seconds).
+    ttl: Option<u16>,
+}
+
+/// Parameters for updating a Sync Document
+pub struct UpdateParams<'a, T>
+where
+    T: ?Sized + Serialize,
+{
+    pub if_match: Option<String>,
+    /// Any value that can be represented as JSON
+    pub data: &'a T,
+    /// How long the Document should exist before deletion (in seconds).
+    pub ttl: Option<u16>,
+}
+
+/// Parameters for creating a Sync Document with
+/// data converted to a JSON string
+#[skip_serializing_none]
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+struct UpdateParamsWithJson {
+    #[serde(rename(serialize = "If-Match"))]
+    if_match: Option<String>,
+    /// Any value that can be represented as JSON
+    data: String,
+    /// How long the Document should exist before deletion (in seconds).
+    ttl: Option<u16>,
+}
+
+pub struct Documents<'a, 'b> {
+    pub client: &'a Client,
+    pub service_sid: &'b str,
+}
+
+impl<'a, 'b> Documents<'a, 'b> {
+    /// [Creates a Sync Document](https://www.twilio.com/docs/sync/api/document-resource)
+    ///
+    /// Creates a Sync Document with the provided parameters.
+    pub async fn create<T>(&self, params: CreateParams<'_, T>) -> Result<Environment, TwilioError>
+    where
+        T: ?Sized + Serialize,
+    {
+        let params = CreateParamsWithJson {
+            unique_name: params.unique_name,
+            data: serde_json::to_string(params.data)
+                .expect("Unable to convert provided data value to a JSON string"),
+            ttl: params.ttl,
+        };
+
+        self.client
+            .send_request::<Environment, CreateParamsWithJson>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents",
+                    self.service_sid
+                ),
+                Some(&params),
+                None,
+            )
+            .await
+    }
+
+    /// [Lists Sync Documents](https://www.twilio.com/docs/sync/api/document-resource#read-multiple-document-resources)
+    ///
+    /// Lists Sync Documents in the Sync Service provided to the `service()`.
+    ///
+    /// Documents will be _eagerly_ paged until all retrieved.
+    pub async fn list(&self) -> Result<Vec<Environment>, TwilioError> {
+        let mut documents_page = self
+            .client
+            .send_request::<EnvironmentPage, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents?PageSize=50",
+                    self.service_sid
+                ),
+                None,
+                None,
+            )
+            .await?;
+
+        let mut results: Vec<Environment> = documents_page.documents;
+
+        while (documents_page.meta.next_page_url).is_some() {
+            documents_page = self
+                .client
+                .send_request::<EnvironmentPage, ()>(
+                    Method::GET,
+                    &documents_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
+
+            results.append(&mut documents_page.documents);
+        }
+
+        Ok(results)
+    }
+}
+
+pub struct Document<'a, 'b> {
+    pub client: &'a Client,
+    pub service_sid: &'b str,
+    /// SID of the Sync Document. Can also be the friendly name.
+    pub sid: &'b str,
+}
+
+impl<'a, 'b> Document<'a, 'b> {
+    /// [Gets a Sync Document](https://www.twilio.com/docs/sync/api/document-resource#fetch-a-document-resource)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument and fetches the Document
+    /// provided to the `document()` argument.
+    pub async fn get(&self) -> Result<Environment, TwilioError> {
+        self.client
+            .send_request::<Environment, ()>(
+                Method::GET,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents/{}",
+                    self.service_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await
+    }
+
+    /// [Update a Sync Document](https://www.twilio.com/docs/sync/api/document-resource#update-a-document-resource)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument and updates the Document
+    /// provided to the `document()` argument.
+    pub async fn update<T>(&self, params: UpdateParams<'_, T>) -> Result<Environment, TwilioError>
+    where
+        T: ?Sized + Serialize,
+    {
+        // Create a new struct with the provided data parameter converted to a
+        // JSON string as required by Twilio.
+        let params = UpdateParamsWithJson {
+            if_match: params.if_match,
+            data: serde_json::to_string(params.data)
+                .expect("Unable to convert provided data value to a JSON string"),
+            ttl: params.ttl,
+        };
+
+        let mut headers = HeaderMap::new();
+
+        if let Some(if_match) = params.if_match.clone() {
+            headers.append("If-Match", if_match.parse().unwrap());
+        }
+
+        self.client
+            .send_request::<Environment, UpdateParamsWithJson>(
+                Method::POST,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents/{}",
+                    self.service_sid, self.sid
+                ),
+                Some(&params),
+                Some(headers),
+            )
+            .await
+    }
+
+    /// [Deletes a Sync Service](https://www.twilio.com/docs/sync/api/service#delete-a-service-resourcee)
+    ///
+    /// Targets the Sync Service provided to the `service()` argument and deletes the Document
+    /// provided to the `document()` argument.
+    pub async fn delete(&self) -> Result<(), TwilioError> {
+        self.client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!(
+                    "https://sync.twilio.com/v1/Services/{}/Documents/{}",
+                    self.service_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await
+    }
+}

--- a/twilly/src/serverless/environments.rs
+++ b/twilly/src/serverless/environments.rs
@@ -84,11 +84,11 @@ impl<'a, 'b> Environments<'a, 'b> {
             .await
     }
 
-    /// [Lists Sync Documents](https://www.twilio.com/docs/sync/api/document-resource#read-multiple-document-resources)
+    /// [Lists Environments](https://www.twilio.com/docs/serverless/api/resource/environment#read-multiple-environment-resources)
     ///
-    /// Lists Sync Documents in the Sync Service provided to the `service()`.
+    /// Lists Environments for the Service provided to the `service()` argument.
     ///
-    /// Documents will be _eagerly_ paged until all retrieved.
+    /// Environments will be _eagerly_ paged until all retrieved.
     pub async fn list(&self) -> Result<Vec<ServerlessEnvironment>, TwilioError> {
         let mut environments_page = self
             .client
@@ -179,7 +179,7 @@ impl<'a, 'b> Environment<'a, 'b> {
         }
     }
 
-    /// General Sync Map Item functions.
+    /// General Log functions.
     pub fn logs(&'a self) -> Logs {
         Logs {
             client: self.client,

--- a/twilly/src/serverless/environments/logs.rs
+++ b/twilly/src/serverless/environments/logs.rs
@@ -93,8 +93,6 @@ impl<'a, 'b> Logs<'a, 'b> {
             start_date: start_date.map(|sd| sd.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
             end_date: end_date.map(|ed| ed.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
         };
-        dbg!(&params.start_date);
-        dbg!(&params.end_date);
 
         let mut logs_page = self
             .client

--- a/twilly/src/serverless/environments/logs.rs
+++ b/twilly/src/serverless/environments/logs.rs
@@ -85,28 +85,16 @@ impl<'a, 'b> Logs<'a, 'b> {
     pub async fn list(
         &self,
         function_sid: Option<String>,
-        start_date: Option<chrono::NaiveDate>,
-        end_date: Option<chrono::NaiveDate>,
+        start_date: Option<chrono::DateTime<chrono::Utc>>,
+        end_date: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<Vec<ServerlessLog>, TwilioError> {
-        let start_date_param =
-            start_date.map(|start_date| start_date.format("%Y-%m-%dT00:00:00Z").to_string());
-
-        // If our end date is today we can only retrieve up until the current time otherwise we can
-        // set the time manually to fetch the full day.
-        let end_date_param = end_date.map(|end_date| {
-            let now = Utc::now();
-            if end_date == now.date_naive() {
-                now.format("%Y-%m-%dT%H:%M:%SZ").to_string()
-            } else {
-                end_date.format("%Y-%m-%dT23:59:59Z").to_string()
-            }
-        });
-
         let params = ListParams {
             function_sid,
-            start_date: start_date_param,
-            end_date: end_date_param,
+            start_date: start_date.map(|sd| sd.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+            end_date: end_date.map(|ed| ed.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
         };
+        dbg!(&params.start_date);
+        dbg!(&params.end_date);
 
         let mut logs_page = self
             .client

--- a/twilly/src/serverless/environments/logs.rs
+++ b/twilly/src/serverless/environments/logs.rs
@@ -5,6 +5,7 @@ Contains Twilio Serverless Environment Logs related functionality.
 */
 
 use crate::{Client, PageMeta, TwilioError};
+use chrono::Utc;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
@@ -57,6 +58,16 @@ pub enum Level {
     Error,
 }
 
+/// Arguments for listing Serverless Logs
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+pub struct ListParams {
+    // The SID of the specific function producing logs.
+    pub function_sid: Option<String>,
+    pub start_date: Option<String>,
+    pub end_date: Option<String>,
+}
+
 pub struct Logs<'a, 'b> {
     pub client: &'a Client,
     pub service_sid: &'b str,
@@ -69,17 +80,43 @@ impl<'a, 'b> Logs<'a, 'b> {
     /// Lists Logs of the Environment provided to `environment()` under the Serverless Service
     /// provided to the `service()`.
     ///
-    /// Logs will be _eagerly_ paged until all retrieved.
-    pub async fn list(&self) -> Result<Vec<ServerlessLog>, TwilioError> {
+    /// Logs will be _eagerly_ paged until all retrieved. If `start_date` is None, this defaults to 1 day in the
+    /// past. If `end_date` is None, this defaults to the current datetime.
+    pub async fn list(
+        &self,
+        function_sid: Option<String>,
+        start_date: Option<chrono::NaiveDate>,
+        end_date: Option<chrono::NaiveDate>,
+    ) -> Result<Vec<ServerlessLog>, TwilioError> {
+        let start_date_param =
+            start_date.map(|start_date| start_date.format("%Y-%m-%dT00:00:00Z").to_string());
+
+        // If our end date is today we can only retrieve up until the current time otherwise we can
+        // set the time manually to fetch the full day.
+        let end_date_param = end_date.map(|end_date| {
+            let now = Utc::now();
+            if end_date == now.date_naive() {
+                now.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+            } else {
+                end_date.format("%Y-%m-%dT23:59:59Z").to_string()
+            }
+        });
+
+        let params = ListParams {
+            function_sid,
+            start_date: start_date_param,
+            end_date: end_date_param,
+        };
+
         let mut logs_page = self
             .client
-            .send_request::<LogsPage, ()>(
+            .send_request::<LogsPage, ListParams>(
                 Method::GET,
                 &format!(
                     "https://serverless.twilio.com/v1/Services/{}/Environments/{}/Logs?PageSize=500",
                     self.service_sid, self.environment_sid
                 ),
-                None,
+                Some(&params),
                 None,
             )
             .await?;

--- a/twilly/src/serverless/environments/logs.rs
+++ b/twilly/src/serverless/environments/logs.rs
@@ -5,7 +5,6 @@ Contains Twilio Serverless Environment Logs related functionality.
 */
 
 use crate::{Client, PageMeta, TwilioError};
-use chrono::Utc;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumString};

--- a/twilly/src/serverless/environments/logs.rs
+++ b/twilly/src/serverless/environments/logs.rs
@@ -1,0 +1,133 @@
+/*!
+
+Contains Twilio Serverless Environment Logs related functionality.
+
+*/
+
+use crate::{Client, PageMeta, TwilioError};
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+
+/// Represents a page of Serverless Environments from the Twilio API.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+pub struct LogsPage {
+    logs: Vec<ServerlessLog>,
+    meta: PageMeta,
+}
+
+/// A Serverless Environment resource.
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct ServerlessLog {
+    pub sid: String,
+    pub account_sid: String,
+    pub service_sid: String,
+    pub environment_sid: String,
+    pub build_sid: String,
+    pub deployment_sid: String,
+    pub function_sid: String,
+    pub request_sid: String,
+    pub level: Level,
+    pub message: String,
+    pub date_created: String,
+    pub url: String,
+}
+
+#[serde(rename_all = "lowercase")]
+#[derive(
+    AsRefStr,
+    Clone,
+    Display,
+    Default,
+    Debug,
+    EnumIter,
+    EnumString,
+    Serialize,
+    Deserialize,
+    PartialEq,
+)]
+pub enum Level {
+    #[default]
+    #[strum(to_string = "Info")]
+    Info,
+    #[strum(to_string = "Warn")]
+    Warn,
+    #[strum(to_string = "Error")]
+    Error,
+}
+
+pub struct Logs<'a, 'b> {
+    pub client: &'a Client,
+    pub service_sid: &'b str,
+    pub environment_sid: &'b str,
+}
+
+impl<'a, 'b> Logs<'a, 'b> {
+    /// [Lists Logs of an Environment](https://www.twilio.com/docs/serverless/api/resource/logs#read-multiple-log-resources)
+    ///
+    /// Lists Logs of the Environment provided to `environment()` under the Serverless Service
+    /// provided to the `service()`.
+    ///
+    /// Logs will be _eagerly_ paged until all retrieved.
+    pub async fn list(&self) -> Result<Vec<ServerlessLog>, TwilioError> {
+        let mut logs_page = self
+            .client
+            .send_request::<LogsPage, ()>(
+                Method::GET,
+                &format!(
+                    "https://serverless.twilio.com/v1/Services/{}/Environments/{}/Logs?PageSize=500",
+                    self.service_sid, self.environment_sid
+                ),
+                None,
+                None,
+            )
+            .await?;
+
+        let mut results: Vec<ServerlessLog> = logs_page.logs;
+
+        while (logs_page.meta.next_page_url).is_some() {
+            logs_page = self
+                .client
+                .send_request::<LogsPage, ()>(
+                    Method::GET,
+                    &logs_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
+
+            results.append(&mut logs_page.logs);
+        }
+
+        Ok(results)
+    }
+}
+
+pub struct Log<'a, 'b> {
+    pub client: &'a Client,
+    pub service_sid: &'b str,
+    pub environment_sid: &'b str,
+    /// SID of the Log Resource.
+    pub sid: &'b str,
+}
+
+impl<'a, 'b> Log<'a, 'b> {
+    /// [Gets an Log](https://www.twilio.com/docs/serverless/api/resource/logs#fetch-a-log-resource)
+    ///
+    /// Targets the Serverless Service provided to the `service()` argument and the Environment provided to
+    /// the `environment()` argument and fetches a Log provided to the `log()` argument.
+    pub async fn get(&self) -> Result<ServerlessLog, TwilioError> {
+        self.client
+            .send_request::<ServerlessLog, ()>(
+                Method::GET,
+                &format!(
+                    "https://serverless.twilio.com/v1/Services/{}/Environments/{}/Logs/{}",
+                    self.service_sid, self.environment_sid, self.sid
+                ),
+                None,
+                None,
+            )
+            .await
+    }
+}

--- a/twilly/src/serverless/environments/logs.rs
+++ b/twilly/src/serverless/environments/logs.rs
@@ -34,7 +34,6 @@ pub struct ServerlessLog {
     pub url: String,
 }
 
-#[serde(rename_all = "lowercase")]
 #[derive(
     AsRefStr,
     Clone,
@@ -47,6 +46,7 @@ pub struct ServerlessLog {
     Deserialize,
     PartialEq,
 )]
+#[serde(rename_all = "UPPERCASE")]
 pub enum Level {
     #[default]
     #[strum(to_string = "Info")]

--- a/twilly/src/serverless/environments/logs.rs
+++ b/twilly/src/serverless/environments/logs.rs
@@ -17,7 +17,7 @@ pub struct LogsPage {
     meta: PageMeta,
 }
 
-/// A Serverless Environment resource.
+/// A Serverless Environment Log resource.
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct ServerlessLog {
     pub sid: String,

--- a/twilly/src/serverless/services.rs
+++ b/twilly/src/serverless/services.rs
@@ -1,0 +1,191 @@
+/*!
+
+Contains Twilio Serverless related functionality.
+
+*/
+
+use crate::{Client, PageMeta, TwilioError};
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use super::environments::{Environment, Environments};
+
+/// Represents a page of Services from the Twilio API.
+#[allow(dead_code)]
+#[derive(Deserialize)]
+pub struct ServerlessServicePage {
+    services: Vec<ServerlessService>,
+    meta: PageMeta,
+}
+
+/// A Serverless Service resource.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ServerlessService {
+    pub sid: String,
+    pub account_sid: String,
+    pub unique_name: String,
+    pub friendly_name: String,
+    /// Whether account credentials are accessible in function executions.
+    pub include_credentials: bool,
+    /// Whether code and configuration can be controlled from the Twilio Console.
+    pub ui_editable: bool,
+    /// The base domain name of the service (combination of `unique_name` and random numbers)
+    pub domain_base: String,
+    pub date_created: String,
+    pub date_updated: String,
+    pub url: String,
+    pub links: Links,
+}
+
+/// Resources _linked_ to a Service
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct Links {
+    pub environments: String,
+    pub functions: String,
+    pub assets: String,
+    pub builds: String,
+}
+
+/// Parameters for creating or updating a Serverlesss Service. See `ServerlessService` for
+/// details on individual parameters.
+#[skip_serializing_none]
+#[derive(Serialize)]
+#[serde(rename_all(serialize = "PascalCase"))]
+pub struct CreateOrUpdateParams {
+    pub unique_name: String,
+    pub friendly_name: String,
+    pub include_credentials: Option<bool>,
+    pub ui_editable: Option<bool>,
+}
+
+pub struct Services<'a> {
+    pub client: &'a Client,
+}
+
+impl<'a> Services<'a> {
+    /// [Creates a Serverless Service](https://www.twilio.com/docs/serverless/api/resource/service#create-a-service-resource)
+    ///
+    /// Creates a Serverless Service resource with the provided parameters.
+    pub async fn create(
+        &self,
+        params: CreateOrUpdateParams,
+    ) -> Result<ServerlessService, TwilioError> {
+        self.client
+            .send_request::<ServerlessService, CreateOrUpdateParams>(
+                Method::POST,
+                "https://serverless.twilio.com/v1/Services",
+                Some(&params),
+                None,
+            )
+            .await
+    }
+
+    //// [Lists Serverless Services](https://www.twilio.com/docs/serverless/api/resource/service#read-multiple-service-resources)
+    ///
+    /// List Serverless Services existing on the Twilio account.
+    ///
+    /// Services will be _eagerly_ paged until all retrieved.
+    pub async fn list(&self) -> Result<Vec<ServerlessService>, TwilioError> {
+        let mut services_page = self
+            .client
+            .send_request::<ServerlessServicePage, ()>(
+                Method::GET,
+                "https://serverless.twilio.com/v1/Services?PageSize=20",
+                None,
+                None,
+            )
+            .await?;
+
+        let mut results: Vec<ServerlessService> = services_page.services;
+
+        while (services_page.meta.next_page_url).is_some() {
+            services_page = self
+                .client
+                .send_request::<ServerlessServicePage, ()>(
+                    Method::GET,
+                    &services_page.meta.next_page_url.unwrap(),
+                    None,
+                    None,
+                )
+                .await?;
+
+            results.append(&mut services_page.services);
+        }
+
+        Ok(results)
+    }
+}
+
+pub struct Service<'a, 'b> {
+    pub client: &'a Client,
+    pub sid: &'b str,
+}
+
+impl<'a, 'b> Service<'a, 'b> {
+    /// [Gets a Serverless Service](https://www.twilio.com/docs/serverless/api/resource/service#fetch-a-service-resource)
+    ///
+    /// Fetches the Serverless Service provided to the `Service()`.
+    pub async fn get(&self) -> Result<ServerlessService, TwilioError> {
+        self.client
+            .send_request::<ServerlessService, ()>(
+                Method::GET,
+                &format!("https://serverless.twilio.com/v1/Services/{}", self.sid),
+                None,
+                None,
+            )
+            .await
+    }
+
+    /// [Update a Serverless Service](https://www.twilio.com/docs/serverless/api/resource/service#update-a-service-resource)
+    ///
+    /// Targets the Serverless Service provided to the `Service()` argument and updates the resource with
+    /// the provided properties
+    pub async fn update(
+        &self,
+        params: CreateOrUpdateParams,
+    ) -> Result<ServerlessService, TwilioError> {
+        self.client
+            .send_request::<ServerlessService, CreateOrUpdateParams>(
+                Method::POST,
+                &format!("https://serverless.twilio.com/v1/Services/{}", self.sid),
+                Some(&params),
+                None,
+            )
+            .await
+    }
+
+    /// [Deletes a Serverless Service](https://www.twilio.com/docs/serverless/api/resource/service#delete-a-service-resource)
+    ///
+    /// Targets the Serverless Service provided to the `Service()` argument and deletes the resource.
+    /// **Use with caution.**
+    pub async fn delete(&self) -> Result<(), TwilioError> {
+        self.client
+            .send_request_and_ignore_response::<()>(
+                Method::DELETE,
+                &format!("https://serverless.twilio.com/v1/Services/{}", self.sid),
+                None,
+                None,
+            )
+            .await
+    }
+
+    /// Actions relating to a known Service Environment.
+    ///
+    /// Takes in the SID of the Environment to perform actions against.
+    pub fn environment(&'a self, sid: &'b str) -> Environment {
+        Environment {
+            client: self.client,
+            service_sid: self.sid,
+            sid,
+        }
+    }
+
+    /// General Service Environment actions.
+    pub fn environments(&'a self) -> Environments {
+        Environments {
+            client: self.client,
+            service_sid: self.sid,
+        }
+    }
+}

--- a/twilly_cli/Cargo.toml
+++ b/twilly_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twilly_cli"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "A CLI tool for interacting the Twilio API built upon the twilly crate"
 authors = ["Tristan Blackwell"]
@@ -15,7 +15,7 @@ rust-version = "1.74.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-twilly = { path = "../twilly", version = "0.1.1" }
+twilly = { path = "../twilly", version = "0.2.0" }
 inquire = { version = "0.6.2", features = ["date"] }
 chrono = "0.4.31"
 strum = "0.26.1"

--- a/twilly_cli/Cargo.toml
+++ b/twilly_cli/Cargo.toml
@@ -24,3 +24,4 @@ confy = "0.6.0"
 openssl = { version = "0.10", features = ["vendored"] }
 tokio = { version = "1.37.0", features = ["macros", "time"] }
 regex = { version = "1.10.4" }
+serde_json = "1.0.127"

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -1,7 +1,7 @@
+use chrono::Datelike;
 use std::{process, str::FromStr};
 
-use chrono::Datelike;
-use inquire::{validator::Validation, Confirm, DateSelect, Select, Text};
+use inquire::{validator::Validation, Confirm, Select, Text};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 use twilly::{
@@ -9,8 +9,8 @@ use twilly::{
     Client, ErrorKind,
 };
 use twilly_cli::{
-    get_action_choice_from_user, get_filter_choice_from_user, prompt_user, prompt_user_selection,
-    ActionChoice, FilterChoice,
+    get_action_choice_from_user, get_date_from_user, get_filter_choice_from_user, prompt_user,
+    prompt_user_selection, ActionChoice, DateRange, FilterChoice,
 };
 
 #[derive(Clone, Display, EnumIter, EnumString)]
@@ -749,43 +749,4 @@ async fn delete_conversation(twilio: &Client, sid: &str) {
             }
         }
     }
-}
-
-struct DateRange {
-    minimum_date: chrono::NaiveDate,
-    maximum_date: chrono::NaiveDate,
-}
-
-fn get_date_from_user(message: &str, date_range: Option<DateRange>) -> Option<chrono::NaiveDate> {
-    let selected_date = match date_range {
-        Some(date_range) => {
-            let date_selection_prompt = DateSelect::new(message)
-                .with_min_date(
-                    chrono::NaiveDate::from_ymd_opt(
-                        date_range.minimum_date.year(),
-                        date_range.minimum_date.month(),
-                        date_range.minimum_date.day(),
-                    )
-                    .unwrap(),
-                )
-                .with_max_date(
-                    chrono::NaiveDate::from_ymd_opt(
-                        date_range.maximum_date.year(),
-                        date_range.maximum_date.month(),
-                        date_range.maximum_date.day(),
-                    )
-                    .unwrap(),
-                )
-                .with_week_start(chrono::Weekday::Mon);
-
-            prompt_user(date_selection_prompt)
-        }
-        None => {
-            let date_selection_prompt =
-                DateSelect::new(message).with_week_start(chrono::Weekday::Mon);
-            prompt_user(date_selection_prompt)
-        }
-    };
-
-    selected_date
 }

--- a/twilly_cli/src/main.rs
+++ b/twilly_cli/src/main.rs
@@ -1,5 +1,6 @@
 mod account;
 mod conversation;
+mod serverless;
 mod sync;
 
 use std::{process, str::FromStr};
@@ -84,6 +85,9 @@ async fn main() {
                 conversation::choose_conversation_action(&twilio).await
             }
             twilly::SubResource::Sync => sync::choose_sync_resource(&twilio).await,
+            twilly::SubResource::Serverless => {
+                serverless::choose_serverless_resource(&twilio).await
+            }
         }
     }
 }

--- a/twilly_cli/src/serverless.rs
+++ b/twilly_cli/src/serverless.rs
@@ -1,0 +1,201 @@
+mod environments;
+
+use std::process;
+
+use inquire::{validator::Validation, Confirm, Select, Text};
+use regex::Regex;
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{serverless::services::CreateOrUpdateParams, Client};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+
+#[derive(Debug, Clone, Display, EnumIter, EnumString)]
+pub enum Action {
+    #[strum(to_string = "List Details")]
+    ListDetails,
+    Environments,
+    Delete,
+    Back,
+    Exit,
+}
+
+pub async fn choose_serverless_resource(twilio: &Client) {
+    let mut serverless_services = twilio
+        .serverless()
+        .services()
+        .list()
+        .await
+        .unwrap_or_else(|error| panic!("{}", error));
+
+    if serverless_services.is_empty() {
+        println!("No Serverless Services found.");
+        return;
+    }
+
+    println!("Found {} Serverless Services.", serverless_services.len());
+
+    let mut selected_serverless_service_index: Option<usize> = None;
+    loop {
+        let selected_serverless_service = if let Some(index) = selected_serverless_service_index {
+            &mut serverless_services[index]
+        } else {
+            let mut existing_services = serverless_services
+                .iter()
+                .map(|service| format!("({}) {}", service.sid, service.unique_name))
+                .collect::<Vec<String>>();
+            existing_services.push("Create Serverless Service".into());
+            if let Some(action_choice) =
+                get_action_choice_from_user(existing_services, "Choose a Serverless Service: ")
+            {
+                match action_choice {
+                    ActionChoice::Back => {
+                        break;
+                    }
+                    ActionChoice::Exit => process::exit(0),
+                    ActionChoice::Other(choice) => {
+                        if choice == "Create Serverless Service" {
+                            let unique_name_prompt = Text::new("Enter a unique name:")
+                                .with_validator(|val: &str| {
+                                    if val.len() <= 50 {
+                                        Ok(Validation::Valid)
+                                    } else {
+                                        Ok(Validation::Invalid(
+                                            "Unique name must be less than 50 characters".into(),
+                                        ))
+                                    }
+                                })
+                                .with_validator(|val: &str| {
+                                    let allowed_chars =
+                                        Regex::new(r"^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$").unwrap();
+                                    let trimmed_name = val.trim();
+                                    if !allowed_chars.is_match(trimmed_name) {
+                                        return Ok(Validation::Invalid(
+                                            "Name doesn't match required filter '^[a-zA-Z0-9-_]+$'"
+                                                .into(),
+                                        ));
+                                    }
+
+                                    Ok(Validation::Valid)
+                                });
+
+                            if let Some(unique_name) = prompt_user(unique_name_prompt) {
+                                let friendly_name_prompt = Text::new(
+                                    "Enter a friendly name (empty to use the unique name):",
+                                );
+
+                                if let Some(friendly_name) = prompt_user(friendly_name_prompt) {
+                                    let mut friendly_name = friendly_name;
+                                    if friendly_name.is_empty() {
+                                        friendly_name = unique_name.clone()
+                                    }
+
+                                    let credentials_confirmation_prompt =
+                                    Confirm::new("Would you like to include Twilio credentials for function invocations?")
+                                        .with_placeholder("Y")
+                                        .with_default(true);
+
+                                    if let Some(credentials_confirmation) =
+                                        prompt_user(credentials_confirmation_prompt)
+                                    {
+                                        let ui_editable_confirmation_prompt =
+                                    Confirm::new("Would you like the service to be editable via the Console?")
+                                        .with_placeholder("N")
+                                        .with_default(false);
+
+                                        if let Some(ui_editable_confirmation) =
+                                            prompt_user(ui_editable_confirmation_prompt)
+                                        {
+                                            let serverless_service = twilio
+                                                .serverless()
+                                                .services()
+                                                .create(CreateOrUpdateParams {
+                                                    unique_name,
+                                                    friendly_name,
+                                                    include_credentials: Some(
+                                                        credentials_confirmation,
+                                                    ),
+                                                    ui_editable: Some(ui_editable_confirmation),
+                                                })
+                                                .await
+                                                .unwrap_or_else(|error| panic!("{}", error));
+                                            serverless_services.push(serverless_service);
+                                            selected_serverless_service_index =
+                                                Some(serverless_services.len() - 1);
+                                            &mut serverless_services
+                                                [selected_serverless_service_index.unwrap()]
+                                        } else {
+                                            break;
+                                        }
+                                    } else {
+                                        break;
+                                    }
+                                } else {
+                                    break;
+                                }
+                            } else {
+                                break;
+                            }
+                        } else {
+                            let serverless_service_position = serverless_services
+                                .iter()
+                                .position(|serverless_service| {
+                                    serverless_service.sid == choice[1..35]
+                                })
+                                .expect(
+                                    "Could not find Serverless Service in existing Serverless Service list",
+                                );
+
+                            selected_serverless_service_index = Some(serverless_service_position);
+                            &mut serverless_services[serverless_service_position]
+                        }
+                    }
+                }
+            } else {
+                break;
+            }
+        };
+
+        let options: Vec<Action> = Action::iter().collect();
+        let resource_selection_prompt = Select::new("Select an action:", options.clone());
+        if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
+            match resource {
+                Action::ListDetails => {
+                    println!("{:#?}", selected_serverless_service);
+                    println!();
+                }
+                Action::Environments => {
+                    environments::choose_environment_action(twilio, selected_serverless_service)
+                        .await
+                }
+                Action::Delete => {
+                    let confirm_prompt =
+                        Confirm::new("Are you sure you wish to delete the Serverless Service?")
+                            .with_placeholder("N")
+                            .with_default(false);
+                    let confirmation = prompt_user(confirm_prompt);
+                    if confirmation.is_some() && confirmation.unwrap() {
+                        println!("Deleting Serverless Service...");
+                        twilio
+                            .serverless()
+                            .service(&selected_serverless_service.sid)
+                            .delete()
+                            .await
+                            .unwrap_or_else(|error| panic!("{}", error));
+                        serverless_services.remove(
+                            selected_serverless_service_index.expect(
+                                "Could not find Serverless Service in existing Serverless Services list",
+                            ),
+                        );
+                        println!("Serverless Service deleted.");
+                        println!();
+                        break;
+                    }
+                }
+                Action::Back => {
+                    break;
+                }
+                Action::Exit => process::exit(0),
+            }
+        }
+    }
+}

--- a/twilly_cli/src/serverless/environments.rs
+++ b/twilly_cli/src/serverless/environments.rs
@@ -1,0 +1,121 @@
+mod logs;
+
+use std::process;
+
+use inquire::{Confirm, Select};
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{serverless::services::ServerlessService, Client};
+use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection, ActionChoice};
+
+#[derive(Debug, Clone, Display, EnumIter, EnumString)]
+pub enum Action {
+    // #[strum(to_string = "List Items")]
+    // ListItem,
+    #[strum(to_string = "List Details")]
+    ListDetails,
+    Logs,
+    Delete,
+    Back,
+    Exit,
+}
+
+pub async fn choose_environment_action(twilio: &Client, serverless_service: &ServerlessService) {
+    let mut serverless_environments = twilio
+        .serverless()
+        .service(&serverless_service.sid)
+        .environments()
+        .list()
+        .await
+        .unwrap_or_else(|error| panic!("{}", error));
+
+    if serverless_environments.is_empty() {
+        println!("No Serverless Environments found.");
+        return;
+    }
+
+    println!(
+        "Found {} Serverless Environments.",
+        serverless_environments.len()
+    );
+
+    let mut selected_serverless_environment_index: Option<usize> = None;
+    loop {
+        let selected_serverless_environment = if let Some(index) =
+            selected_serverless_environment_index
+        {
+            &mut serverless_environments[index]
+        } else if let Some(action_choice) = get_action_choice_from_user(
+            serverless_environments
+                .iter()
+                .map(|environment| format!("({}) {}", environment.sid, environment.unique_name))
+                .collect::<Vec<String>>(),
+            "Choose a Serverless Environment: ",
+        ) {
+            match action_choice {
+                ActionChoice::Back => {
+                    break;
+                }
+                ActionChoice::Exit => process::exit(0),
+                ActionChoice::Other(choice) => {
+                    let serverless_environment_position = serverless_environments
+                        .iter()
+                        .position(|list| list.sid == choice[1..35])
+                        .expect("Could not find Serverless Environment in existing Serverless Environment list");
+
+                    selected_serverless_environment_index = Some(serverless_environment_position);
+                    &mut serverless_environments[serverless_environment_position]
+                }
+            }
+        } else {
+            break;
+        };
+
+        let options: Vec<Action> = Action::iter().collect();
+        let resource_selection_prompt = Select::new("Select an action:", options.clone());
+        if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
+            match resource {
+                Action::ListDetails => {
+                    println!("{:#?}", selected_serverless_environment);
+                    println!();
+                }
+                Action::Logs => {
+                    logs::choose_log_action(
+                        twilio,
+                        serverless_service,
+                        selected_serverless_environment,
+                    )
+                    .await
+                }
+                Action::Delete => {
+                    let confirm_prompt =
+                        Confirm::new("Are you sure you wish to delete the Serverless Environment?")
+                            .with_placeholder("N")
+                            .with_default(false);
+                    let confirmation = prompt_user(confirm_prompt);
+                    if confirmation.is_some() && confirmation.unwrap() {
+                        println!("Deleting Serverless Environment...");
+                        twilio
+                            .sync()
+                            .service(&serverless_service.sid)
+                            .list(&selected_serverless_environment.sid)
+                            .delete()
+                            .await
+                            .unwrap_or_else(|error| panic!("{}", error));
+                        serverless_environments.remove(
+                            selected_serverless_environment_index
+                                .expect("Could not find Serverless Environment in existing Serverless Environment list"),
+                        );
+                        println!("Serverless Environment deleted.");
+                        println!();
+                        break;
+                    }
+                }
+                Action::Back => {
+                    break;
+                }
+                Action::Exit => process::exit(0),
+            }
+        }
+    }
+}

--- a/twilly_cli/src/serverless/environments.rs
+++ b/twilly_cli/src/serverless/environments.rs
@@ -10,8 +10,6 @@ use twilly_cli::{get_action_choice_from_user, prompt_user, prompt_user_selection
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
 pub enum Action {
-    // #[strum(to_string = "List Items")]
-    // ListItem,
     #[strum(to_string = "List Details")]
     ListDetails,
     Logs,

--- a/twilly_cli/src/serverless/environments/logs.rs
+++ b/twilly_cli/src/serverless/environments/logs.rs
@@ -1,19 +1,34 @@
+use chrono::Datelike;
 use std::process;
 
-use inquire::Select;
+use inquire::{validator::Validation, Confirm, MultiSelect, Select, Text};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 use twilly::{
-    serverless::{environments::ServerlessEnvironment, services::ServerlessService},
-    Client,
+    serverless::{
+        environments::{logs::Level, ServerlessEnvironment},
+        services::ServerlessService,
+    },
+    Client, ErrorKind,
 };
-use twilly_cli::{get_action_choice_from_user, prompt_user_selection, ActionChoice};
+use twilly_cli::{
+    get_action_choice_from_user, get_date_from_user, prompt_user, prompt_user_multi_selection,
+    prompt_user_selection, ActionChoice, DateRange,
+};
 
 #[derive(Debug, Clone, Display, EnumIter, EnumString)]
-pub enum Action {
-    // #[strum(to_string = "List Items")]
-    // ListItem,
-    #[strum(to_string = "List Details")]
+pub enum LogsAction {
+    #[strum(to_string = "Get Log")]
+    GetLog,
+    #[strum(to_string = "List Logs")]
+    ListLogs,
+    Back,
+    Exit,
+}
+
+#[derive(Debug, Clone, Display, EnumIter, EnumString)]
+pub enum LogAction {
+    #[strum(to_string = "List details")]
     ListDetails,
     Back,
     Exit,
@@ -24,67 +39,258 @@ pub async fn choose_log_action(
     serverless_service: &ServerlessService,
     serverless_environment: &ServerlessEnvironment,
 ) {
-    let mut serverless_logs = twilio
-        .serverless()
-        .service(&serverless_service.sid)
-        .environment(&serverless_environment.sid)
-        .logs()
-        .list()
-        .await
-        .unwrap_or_else(|error| panic!("{}", error));
+    let options: Vec<LogsAction> = LogsAction::iter().collect();
 
-    if serverless_logs.is_empty() {
-        println!("No Serverless Logs found.");
-        return;
-    }
-
-    println!("Found {} Serverless Logs.", serverless_logs.len());
-
-    // Sort date descending (latest first)
-    serverless_logs.sort_by(|a, b| b.date_created.cmp(&a.date_created));
-
-    let mut selected_serverless_log_index: Option<usize> = None;
     loop {
-        let selected_serverless_log = if let Some(index) = selected_serverless_log_index {
-            &mut serverless_logs[index]
-        } else if let Some(action_choice) = get_action_choice_from_user(
-            serverless_logs
-                .iter()
-                .map(|log| format!("({}) {} - {}", log.sid, log.date_created, log.message))
-                .collect::<Vec<String>>(),
-            "Choose a Serverless Log: ",
-        ) {
-            match action_choice {
-                ActionChoice::Back => {
-                    break;
+        let resource_selection_prompt = Select::new("Select an action:", options.clone());
+        if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
+            match resource {
+                LogsAction::GetLog => {
+                    let log_sid_prompt = Text::new("Please provide a Log SID:")
+                        .with_placeholder("NO...")
+                        .with_validator(|val: &str| {
+                            if val.starts_with("NO") && val.len() == 34 {
+                                Ok(Validation::Valid)
+                            } else {
+                                Ok(Validation::Invalid(
+                                    "Log SID should be 34 characters in length".into(),
+                                ))
+                            }
+                        });
+
+                    if let Some(log_sid) = prompt_user(log_sid_prompt) {
+                        match twilio
+                            .serverless()
+                            .service(&serverless_service.sid)
+                            .environment(&serverless_environment.sid)
+                            .log(&log_sid)
+                            .get()
+                            .await
+                        {
+                            Ok(log) => {
+                                println!("Log found.");
+                                println!();
+
+                                if let Some(action_choice) = get_action_choice_from_user(
+                                    vec![String::from("List Details")],
+                                    "Select an action: ",
+                                ) {
+                                    match action_choice {
+                                        ActionChoice::Back => {
+                                            break;
+                                        }
+                                        ActionChoice::Exit => process::exit(0),
+                                        ActionChoice::Other(choice) => match choice.as_str() {
+                                            "List Details" => {
+                                                println!("{:#?}", log);
+                                                println!();
+                                            }
+                                            _ => println!("Unknown action '{}'", choice),
+                                        },
+                                    }
+                                } else {
+                                    break;
+                                }
+                            }
+                            Err(error) => match error.kind {
+                                ErrorKind::TwilioError(twilio_error) => {
+                                    if twilio_error.status == 404 {
+                                        println!("A Log with SID '{}' was not found.", &log_sid);
+                                        println!();
+                                    } else {
+                                        panic!("{}", twilio_error);
+                                    }
+                                }
+                                _ => panic!("{}", error),
+                            },
+                        }
+                    }
                 }
-                ActionChoice::Exit => process::exit(0),
-                ActionChoice::Other(choice) => {
-                    let serverless_log_position = serverless_logs
+                LogsAction::ListLogs => {
+                    let mut start_date: Option<chrono::NaiveDate> = None;
+                    let mut end_date: Option<chrono::NaiveDate> = None;
+
+                    let mut user_filtered_dates = false;
+
+                    let filter_dates_prompt =
+                        Confirm::new("Would you like to filter between specified dates?")
+                            .with_placeholder("N")
+                            .with_default(false);
+
+                    if let Some(date_decision) = prompt_user(filter_dates_prompt) {
+                        if date_decision {
+                            user_filtered_dates = true;
+                            let utc_now = chrono::Utc::now();
+                            let utc_30_days_ago = utc_now - chrono::Duration::days(30);
+                            if let Some(user_start_date) = get_date_from_user(
+                                "Choose a start date:",
+                                Some(DateRange {
+                                    minimum_date: chrono::NaiveDate::from_ymd_opt(
+                                        utc_30_days_ago.year(),
+                                        utc_30_days_ago.month(),
+                                        utc_30_days_ago.day(),
+                                    )
+                                    .unwrap(),
+                                    maximum_date: chrono::NaiveDate::from_ymd_opt(
+                                        utc_now.year(),
+                                        utc_now.month(),
+                                        utc_now.day(),
+                                    )
+                                    .unwrap(),
+                                }),
+                            ) {
+                                start_date = Some(user_start_date);
+                                end_date = get_date_from_user(
+                                    "Choose an end date:",
+                                    Some(DateRange {
+                                        minimum_date: chrono::NaiveDate::from_ymd_opt(
+                                            user_start_date.year_ce().1.try_into().unwrap(),
+                                            user_start_date.month0() + 1,
+                                            user_start_date.day0() + 1,
+                                        )
+                                        .unwrap(),
+                                        maximum_date: chrono::NaiveDate::from_ymd_opt(
+                                            utc_now.year(),
+                                            utc_now.month(),
+                                            utc_now.day(),
+                                        )
+                                        .unwrap(),
+                                    }),
+                                );
+                            }
+                        }
+                    }
+
+                    // Only continue if the user filtered by dates *and* provided both options.
+                    // If they didn't then they must of cancelled the operation.
+                    if !user_filtered_dates || (start_date.is_some() && end_date.is_some()) {
+                        let filter_function =
+                            Confirm::new("Would you like to filter by a specific function?")
+                                .with_placeholder("N")
+                                .with_default(false);
+
+                        if let Some(filter_decision) = prompt_user(filter_function) {
+                            let mut function_sid: Option<String> = None;
+                            if filter_decision {
+                                let function_sid_prompt =
+                                    Text::new("Please provide a function SID:")
+                                        .with_placeholder("ZH...")
+                                        .with_validator(|val: &str| {
+                                            if val.starts_with("ZH") && val.len() == 34 {
+                                                Ok(Validation::Valid)
+                                            } else {
+                                                Ok(Validation::Invalid(
+                                        "Function SID should be 34 characters in length".into(),
+                                    ))
+                                            }
+                                        });
+
+                                if let Some(user_function_sid) = prompt_user(function_sid_prompt) {
+                                    function_sid = Some(user_function_sid);
+                                }
+                            }
+
+                            let options: Vec<Level> = Level::iter().collect();
+                            let log_level_prompt = MultiSelect::new(
+                                "Select the log levels you would like to view:",
+                                options,
+                            )
+                            .with_default(&[0_usize, 1, 2]);
+
+                            if let Some(log_levels) = prompt_user_multi_selection(log_level_prompt)
+                            {
+                                println!("Fetching logs...");
+                                let mut serverless_logs = twilio
+                                    .serverless()
+                                    .service(&serverless_service.sid)
+                                    .environment(&serverless_environment.sid)
+                                    .logs()
+                                    .list(function_sid, start_date, end_date)
+                                    .await
+                                    .unwrap_or_else(|error| panic!("{}", error));
+
+                                println!("Filtering...");
+                                serverless_logs.retain(|log| log_levels.contains(&log.level));
+
+                                let number_of_logs = serverless_logs.len();
+
+                                if number_of_logs == 0 {
+                                    println!("No logs found.");
+                                    println!();
+                                } else {
+                                    println!("Found {} logs.", number_of_logs);
+
+                                    // Sort date descending (latest first)
+                                    serverless_logs
+                                        .sort_by(|a, b| b.date_created.cmp(&a.date_created));
+
+                                    let mut selected_serverless_log_index: Option<usize> = None;
+                                    loop {
+                                        let selected_serverless_log = if let Some(index) =
+                                            selected_serverless_log_index
+                                        {
+                                            &mut serverless_logs[index]
+                                        } else if let Some(action_choice) =
+                                            get_action_choice_from_user(
+                                                serverless_logs
+                                                    .iter()
+                                                    .map(|log| {
+                                                        format!(
+                                                            "({}) {} - {}",
+                                                            log.sid, log.date_created, log.message
+                                                        )
+                                                    })
+                                                    .collect::<Vec<String>>(),
+                                                "Choose a Serverless Log: ",
+                                            )
+                                        {
+                                            match action_choice {
+                                                ActionChoice::Back => {
+                                                    break;
+                                                }
+                                                ActionChoice::Exit => process::exit(0),
+                                                ActionChoice::Other(choice) => {
+                                                    let serverless_log_position = serverless_logs
                         .iter()
                         .position(|list| list.sid == choice[1..35])
                         .expect("Could not find Serverless Log in existing Serverless Log list");
 
-                    selected_serverless_log_index = Some(serverless_log_position);
-                    &mut serverless_logs[serverless_log_position]
-                }
-            }
-        } else {
-            break;
-        };
+                                                    selected_serverless_log_index =
+                                                        Some(serverless_log_position);
+                                                    &mut serverless_logs[serverless_log_position]
+                                                }
+                                            }
+                                        } else {
+                                            break;
+                                        };
 
-        let options: Vec<Action> = Action::iter().collect();
-        let resource_selection_prompt = Select::new("Select an action:", options.clone());
-        if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
-            match resource {
-                Action::ListDetails => {
-                    println!("{:#?}", selected_serverless_log);
-                    println!();
+                                        let options: Vec<LogAction> = LogAction::iter().collect();
+                                        let action_selection_prompt =
+                                            Select::new("Select an action:", options);
+                                        if let Some(action) =
+                                            prompt_user_selection(action_selection_prompt)
+                                        {
+                                            match action {
+                                                LogAction::ListDetails => {
+                                                    println!("{:#?}", selected_serverless_log);
+                                                    println!();
+                                                }
+                                                LogAction::Back => {
+                                                    break;
+                                                }
+                                                LogAction::Exit => process::exit(0),
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
-                Action::Back => {
+                LogsAction::Back => {
                     break;
                 }
-                Action::Exit => process::exit(0),
+                LogsAction::Exit => process::exit(0),
             }
         }
     }

--- a/twilly_cli/src/serverless/environments/logs.rs
+++ b/twilly_cli/src/serverless/environments/logs.rs
@@ -338,12 +338,15 @@ pub async fn choose_log_action(
                                                                     .unwrap()
                                                                     .as_bytes(),
                                                                 ) {
-																	Ok(_) => println!("Log file created"),
-																	Err(error) => eprintln!("Failed to fully write to log file. Action aborted: {error}")
+																	Ok(_) => {
+																		println!("Log file created: {}.json", &serverless_environment.sid); 
+																		println!();
+																	},
+																	Err(error) => eprintln!("Failed to fully write to log file. Action aborted: {}", error)
 																}
                                                         }
                                                         Err(error) => eprintln!(
-                                                            "Unable to create log file. Action aborted: {error}"
+                                                            "Unable to create log file. Action aborted: {}", error
                                                         ),
                                                     }
                                                 }

--- a/twilly_cli/src/serverless/environments/logs.rs
+++ b/twilly_cli/src/serverless/environments/logs.rs
@@ -1,0 +1,91 @@
+use std::process;
+
+use inquire::Select;
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter, EnumString};
+use twilly::{
+    serverless::{environments::ServerlessEnvironment, services::ServerlessService},
+    Client,
+};
+use twilly_cli::{get_action_choice_from_user, prompt_user_selection, ActionChoice};
+
+#[derive(Debug, Clone, Display, EnumIter, EnumString)]
+pub enum Action {
+    // #[strum(to_string = "List Items")]
+    // ListItem,
+    #[strum(to_string = "List Details")]
+    ListDetails,
+    Back,
+    Exit,
+}
+
+pub async fn choose_log_action(
+    twilio: &Client,
+    serverless_service: &ServerlessService,
+    serverless_environment: &ServerlessEnvironment,
+) {
+    let mut serverless_logs = twilio
+        .serverless()
+        .service(&serverless_service.sid)
+        .environment(&serverless_environment.sid)
+        .logs()
+        .list()
+        .await
+        .unwrap_or_else(|error| panic!("{}", error));
+
+    if serverless_logs.is_empty() {
+        println!("No Serverless Logs found.");
+        return;
+    }
+
+    println!("Found {} Serverless Logs.", serverless_logs.len());
+
+    // Sort date descending (latest first)
+    serverless_logs.sort_by(|a, b| b.date_created.cmp(&a.date_created));
+
+    let mut selected_serverless_log_index: Option<usize> = None;
+    loop {
+        let selected_serverless_log = if let Some(index) = selected_serverless_log_index {
+            &mut serverless_logs[index]
+        } else if let Some(action_choice) = get_action_choice_from_user(
+            serverless_logs
+                .iter()
+                .map(|log| format!("({}) {} - {}", log.sid, log.date_created, log.message))
+                .collect::<Vec<String>>(),
+            "Choose a Serverless Log: ",
+        ) {
+            match action_choice {
+                ActionChoice::Back => {
+                    break;
+                }
+                ActionChoice::Exit => process::exit(0),
+                ActionChoice::Other(choice) => {
+                    let serverless_log_position = serverless_logs
+                        .iter()
+                        .position(|list| list.sid == choice[1..35])
+                        .expect("Could not find Serverless Log in existing Serverless Log list");
+
+                    selected_serverless_log_index = Some(serverless_log_position);
+                    &mut serverless_logs[serverless_log_position]
+                }
+            }
+        } else {
+            break;
+        };
+
+        let options: Vec<Action> = Action::iter().collect();
+        let resource_selection_prompt = Select::new("Select an action:", options.clone());
+        if let Some(resource) = prompt_user_selection(resource_selection_prompt) {
+            match resource {
+                Action::ListDetails => {
+                    println!("{:#?}", selected_serverless_log);
+                    println!();
+                }
+                Action::Back => {
+                    break;
+                }
+                Action::Exit => process::exit(0),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extends `twilly` to support a subset of Twilio [Serverless](https://www.twilio.com/docs/serverless/api) resources:

- Service
- Environment
- Log

This has been extended to enhance the `twilly_cli` with the ability to:

- View / create Serverless Services.
- View Environments belonging to a Service.
- Delete Environments.
- Retrieve a Log resource or List Logs for a given environment. These logs can be viewed in the terminal or exported to a JSON file for easier viewing.

> The Logs search is fairly extensive supporting time range presets (30 minutes, 1 hour, 6 hours) or custom dates, target a specific function SID, and filtering by log level (info, warn, error).  