### PR TITLE
Fix: Serverless logs date

### DIFF
--- a/twilly_cli/src/account.rs
+++ b/twilly_cli/src/account.rs
@@ -290,7 +290,6 @@ pub async fn choose_account_action(twilio: &Client) {
     }
 }
 
-#[allow(clippy::println_empty_string)]
 async fn change_account_name(twilio: &Client, account_sid: &str) {
     let friendly_name_prompt =
         Text::new("Provide a name:").with_validator(|val: &str| match !val.is_empty() {
@@ -307,11 +306,10 @@ async fn change_account_name(twilio: &Client, account_sid: &str) {
             .unwrap_or_else(|error| panic!("{}", error));
 
         println!("{:#?}", updated_account);
-        println!("");
+        println!();
     }
 }
 
-#[allow(clippy::println_empty_string)]
 async fn activate_account(twilio: &Client, account_sid: &str) {
     let confirmation_prompt = Confirm::new("Are you sure you wish to activate this account?")
         .with_placeholder("N")

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -33,7 +33,6 @@ pub enum Action {
     Exit,
 }
 
-#[allow(clippy::println_empty_string)]
 pub async fn choose_conversation_action(twilio: &Client) {
     let options: Vec<Action> = Action::iter().collect();
 
@@ -110,7 +109,7 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                             "A Conversation with SID '{}' was not found.",
                                             &conversation_sid
                                         );
-                                        println!("");
+                                        println!();
                                     } else {
                                         panic!("{}", twilio_error);
                                     }
@@ -596,7 +595,7 @@ pub async fn choose_conversation_action(twilio: &Client) {
                     }
 
                     println!("All active conversations closed.");
-                    println!("");
+                    println!();
                     return;
                 }
                 Action::DeleteConversation => {
@@ -655,7 +654,7 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                     }
 
                                     println!("All conversations deleted.");
-                                    println!("");
+                                    println!();
                                     return;
                                 }
                             }
@@ -663,7 +662,7 @@ pub async fn choose_conversation_action(twilio: &Client) {
                     }
 
                     println!("Operation canceled. No changes were made.");
-                    println!("");
+                    println!();
                 }
                 Action::Back => {
                     break;
@@ -722,7 +721,6 @@ async fn close_conversation(twilio: &Client, sid: &str) {
 
 /// Prompts the user for confirmation before deleting the conversation with
 /// the SID provided. Will panic if the delete operation fails.
-#[allow(clippy::println_empty_string)]
 async fn delete_conversation(twilio: &Client, sid: &str) {
     let confirmation_prompt = Confirm::new("Are you sure you wish to delete the Conversation?")
         .with_placeholder("N")
@@ -733,13 +731,13 @@ async fn delete_conversation(twilio: &Client, sid: &str) {
             match twilio.conversations().delete(sid).await {
                 Ok(_) => {
                     println!("Conversation deleted.");
-                    println!("");
+                    println!();
                 }
                 Err(error) => match error.kind {
                     ErrorKind::TwilioError(twilio_error) => {
                         if twilio_error.status == 404 {
                             println!("A Conversation with SID '{}' was not found.", &sid);
-                            println!("");
+                            println!();
                         } else {
                             panic!("{}", twilio_error)
                         }

--- a/twilly_cli/src/main.rs
+++ b/twilly_cli/src/main.rs
@@ -92,20 +92,19 @@ async fn main() {
     }
 }
 
-#[allow(clippy::println_empty_string)]
 fn print_welcome_message() {
-    println!("");
-    println!("");
-    println!("");
+    println!();
+    println!();
+    println!();
     println!(
-        " _____          _ _ _          ____            _
-|_   _|_      _(_) (_) ___    |  _ \\ _   _ ___| |_
-  | | \\ \\ /\\ / / | | |/ _ \\   | |_) | | | / __| __|
-  | |  \\ V  V /| | | | (_) |  |  _ <| |_| \\__ \\ |_
-  |_|   \\_/\\_/ |_|_|_|\\___/___|_| \\_\\\\__,_|___/\\__|
-                         |_____|                   "
+        "___________       .__.__  .__         
+\\__    ___/_  _  _|__|  | |  | ___.__.
+  |    |  \\ \\/ \\/ /  |  | |  |<   |  |
+  |    |   \\     /|  |  |_|  |_\\___  |
+  |____|    \\/\\_/ |__|____/____/ ____|
+                               \\/     "
     );
-    println!("");
+    println!();
     println!("Welcome to Twilly! I'm here to help you interact with Twilio!");
-    println!("");
+    println!();
 }

--- a/twilly_cli/src/serverless/environments/logs.rs
+++ b/twilly_cli/src/serverless/environments/logs.rs
@@ -124,7 +124,7 @@ pub async fn choose_log_action(
                 LogsAction::ListLogs => {
                     let utc_now = chrono::Utc::now();
                     let mut start_date: Option<chrono::DateTime<chrono::Utc>> = None;
-                    let mut end_date: Option<chrono::DateTime<chrono::Utc>> = Some(utc_now);
+                    let mut end_date: Option<chrono::DateTime<chrono::Utc>> = None;
 
                     let mut user_selected_time_range = false;
 
@@ -313,6 +313,7 @@ pub async fn choose_log_action(
                                     println!();
                                 } else {
                                     println!("Found {} logs.", number_of_logs);
+                                    println!();
 
                                     if let Some(output_decision) = get_action_choice_from_user(
                                         vec![String::from("Write to file"), String::from("View")],

--- a/twilly_cli/src/sync/documents.rs
+++ b/twilly_cli/src/sync/documents.rs
@@ -16,7 +16,6 @@ pub enum Action {
     Exit,
 }
 
-#[allow(clippy::println_empty_string)]
 pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService) {
     let options: Vec<Action> = Action::iter().collect();
 
@@ -100,7 +99,7 @@ pub async fn choose_document_action(twilio: &Client, sync_service: &SyncService)
                                             "A Document with SID '{}' was not found.",
                                             &document_sid
                                         );
-                                        println!("");
+                                        println!();
                                     } else {
                                         panic!("{}", twilio_error);
                                     }


### PR DESCRIPTION
See first commit for detail on bug.

Also removes some suppressed clippy warns by resolving the underlying `println!()` statements & updates the CLI ASCII art