### PR TITLE
Fix: Conversation states

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
         "esbenp.prettier-vscode",
         "ms-azuretools.vscode-docker",
         "rust-lang.rust-analyzer",
-        "tamasfe.even-better-toml"
+        "tamasfe.even-better-toml",
+        "fill-labs.dependi"
       ]
     }
   }

--- a/twilly/src/account.rs
+++ b/twilly/src/account.rs
@@ -106,7 +106,7 @@ pub struct CreateParams {
     pub friendly_name: Option<String>,
 }
 
-impl<'a> Accounts<'a> {
+impl Accounts<'_> {
     /// [Gets an Account](https://www.twilio.com/docs/iam/api/account#fetch-an-account-resource)
     ///
     /// Takes in an optional `sid` argument otherwise will default to the current config

--- a/twilly/src/conversation.rs
+++ b/twilly/src/conversation.rs
@@ -31,21 +31,21 @@ pub struct Conversation {
     pub sid: String,
     pub account_sid: String,
     pub chat_service_sid: String,
-    pub messaging_service_sid: String,
+    pub messaging_service_sid: Option<String>,
     pub unique_name: Option<String>,
     pub friendly_name: Option<String>,
     pub date_created: String,
     pub date_updated: String,
-    pub state: State,
+    pub state: Option<State>,
     pub url: String,
     pub attributes: String,
-    pub timers: Timers,
+    pub timers: Option<Timers>,
     pub links: Links,
 }
 
 impl fmt::Display for Conversation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} - {}", self.sid, self.state)
+        write!(f, "{} - {:?}", self.sid, self.state)
     }
 }
 

--- a/twilly/src/conversation.rs
+++ b/twilly/src/conversation.rs
@@ -45,7 +45,12 @@ pub struct Conversation {
 
 impl fmt::Display for Conversation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} - {:?}", self.sid, self.state)
+        write!(
+            f,
+            "{} - {}",
+            self.sid,
+            self.state.as_ref().map_or("None", |s| s.as_ref())
+        )
     }
 }
 

--- a/twilly/src/conversation.rs
+++ b/twilly/src/conversation.rs
@@ -126,7 +126,7 @@ pub struct ListParams {
     pub state: Option<State>,
 }
 
-impl<'a> Conversations<'a> {
+impl Conversations<'_> {
     /// [Gets a Conversation](https://www.twilio.com/docs/conversations/api/conversation-resource#fetch-a-conversation-resource)
     ///
     /// Takes in a `sid` argument which can also be the Conversations `uniqueName`.

--- a/twilly/src/participant_conversation.rs
+++ b/twilly/src/participant_conversation.rs
@@ -74,7 +74,7 @@ struct ListParams {
     address: Option<String>,
 }
 
-impl<'a> ParticipantConversations<'a> {
+impl ParticipantConversations<'_> {
     /// [Lists Participant Conversations](https://www.twilio.com/docs/conversations/api/participant-conversation-resource#list-all-of-a-participants-conversations)
     ///
     /// This will eagerly fetch *all* conversations relating to a particular identity or address on the Twilio account.

--- a/twilly/src/serverless.rs
+++ b/twilly/src/serverless.rs
@@ -20,7 +20,7 @@ impl<'a> Serverless<'a> {
     /// Actions relating to a known Function Service.
     ///
     /// Takes in the SID of the Service to perform actions against.
-    pub fn service<'b: 'a>(&'a self, sid: &'b str) -> Service {
+    pub fn service<'b: 'a>(&self, sid: &'b str) -> Service {
         Service {
             client: self.client,
             sid,
@@ -28,7 +28,7 @@ impl<'a> Serverless<'a> {
     }
 
     /// General Function Service actions.
-    pub fn services(&'a self) -> Services {
+    pub fn services(&self) -> Services {
         Services {
             client: self.client,
         }

--- a/twilly/src/serverless/environments.rs
+++ b/twilly/src/serverless/environments.rs
@@ -60,7 +60,7 @@ pub struct Environments<'a, 'b> {
     pub service_sid: &'b str,
 }
 
-impl<'a, 'b> Environments<'a, 'b> {
+impl Environments<'_, '_> {
     /// [Creates an Environment](https://www.twilio.com/docs/serverless/api/resource/environment#create-an-environment-resource)
     ///
     /// Creates an Environment with the provided parameters.
@@ -130,7 +130,7 @@ pub struct Environment<'a, 'b> {
     pub sid: &'b str,
 }
 
-impl<'a, 'b> Environment<'a, 'b> {
+impl<'b> Environment<'_, 'b> {
     /// [Gets an Environment](https://www.twilio.com/docs/serverless/api/resource/environment#fetch-an-environment-resource)
     ///
     /// Targets the Serverless Service provided to the `service()` argument and fetches the Environment

--- a/twilly/src/serverless/environments.rs
+++ b/twilly/src/serverless/environments.rs
@@ -170,7 +170,7 @@ impl<'a, 'b> Environment<'a, 'b> {
     /// Functions relating to a known Environment Log.
     ///
     /// Takes in the key of the Sync List Item to perform actions against.
-    pub fn log(&'a self, sid: &'b str) -> Log {
+    pub fn log(&self, sid: &'b str) -> Log {
         Log {
             client: self.client,
             service_sid: self.service_sid,
@@ -180,7 +180,7 @@ impl<'a, 'b> Environment<'a, 'b> {
     }
 
     /// General Log functions.
-    pub fn logs(&'a self) -> Logs {
+    pub fn logs(&self) -> Logs {
         Logs {
             client: self.client,
             service_sid: self.service_sid,

--- a/twilly/src/serverless/environments/logs.rs
+++ b/twilly/src/serverless/environments/logs.rs
@@ -73,7 +73,7 @@ pub struct Logs<'a, 'b> {
     pub environment_sid: &'b str,
 }
 
-impl<'a, 'b> Logs<'a, 'b> {
+impl Logs<'_, '_> {
     /// [Lists Logs of an Environment](https://www.twilio.com/docs/serverless/api/resource/logs#read-multiple-log-resources)
     ///
     /// Lists Logs of the Environment provided to `environment()` under the Serverless Service
@@ -134,7 +134,7 @@ pub struct Log<'a, 'b> {
     pub sid: &'b str,
 }
 
-impl<'a, 'b> Log<'a, 'b> {
+impl Log<'_, '_> {
     /// [Gets an Log](https://www.twilio.com/docs/serverless/api/resource/logs#fetch-a-log-resource)
     ///
     /// Targets the Serverless Service provided to the `service()` argument and the Environment provided to

--- a/twilly/src/serverless/services.rs
+++ b/twilly/src/serverless/services.rs
@@ -63,7 +63,7 @@ pub struct Services<'a> {
     pub client: &'a Client,
 }
 
-impl<'a> Services<'a> {
+impl Services<'_> {
     /// [Creates a Serverless Service](https://www.twilio.com/docs/serverless/api/resource/service#create-a-service-resource)
     ///
     /// Creates a Serverless Service resource with the provided parameters.
@@ -122,7 +122,7 @@ pub struct Service<'a, 'b> {
     pub sid: &'b str,
 }
 
-impl<'a, 'b> Service<'a, 'b> {
+impl<'b> Service<'_, 'b> {
     /// [Gets a Serverless Service](https://www.twilio.com/docs/serverless/api/resource/service#fetch-a-service-resource)
     ///
     /// Fetches the Serverless Service provided to the `Service()`.

--- a/twilly/src/serverless/services.rs
+++ b/twilly/src/serverless/services.rs
@@ -173,7 +173,7 @@ impl<'a, 'b> Service<'a, 'b> {
     /// Actions relating to a known Service Environment.
     ///
     /// Takes in the SID of the Environment to perform actions against.
-    pub fn environment(&'a self, sid: &'b str) -> Environment {
+    pub fn environment(&self, sid: &'b str) -> Environment {
         Environment {
             client: self.client,
             service_sid: self.sid,
@@ -182,7 +182,7 @@ impl<'a, 'b> Service<'a, 'b> {
     }
 
     /// General Service Environment actions.
-    pub fn environments(&'a self) -> Environments {
+    pub fn environments(&self) -> Environments {
         Environments {
             client: self.client,
             service_sid: self.sid,

--- a/twilly/src/sync.rs
+++ b/twilly/src/sync.rs
@@ -24,7 +24,7 @@ impl<'a> Sync<'a> {
     /// Functions relating to a known Sync Service.
     ///
     /// Takes in the SID of the Sync Service to perform actions against.
-    pub fn service<'b: 'a>(&'a self, sid: &'b str) -> Service {
+    pub fn service<'b: 'a>(&self, sid: &'b str) -> Service {
         Service {
             client: self.client,
             sid,
@@ -32,7 +32,7 @@ impl<'a> Sync<'a> {
     }
 
     /// General Sync Service functions.
-    pub fn services(&'a self) -> Services {
+    pub fn services(&self) -> Services {
         Services {
             client: self.client,
         }

--- a/twilly/src/sync/documents.rs
+++ b/twilly/src/sync/documents.rs
@@ -97,7 +97,7 @@ pub struct Documents<'a, 'b> {
     pub service_sid: &'b str,
 }
 
-impl<'a, 'b> Documents<'a, 'b> {
+impl Documents<'_, '_> {
     /// [Creates a Sync Document](https://www.twilio.com/docs/sync/api/document-resource)
     ///
     /// Creates a Sync Document with the provided parameters.
@@ -171,7 +171,7 @@ pub struct Document<'a, 'b> {
     pub sid: &'b str,
 }
 
-impl<'a, 'b> Document<'a, 'b> {
+impl Document<'_, '_> {
     /// [Gets a Sync Document](https://www.twilio.com/docs/sync/api/document-resource#fetch-a-document-resource)
     ///
     /// Targets the Sync Service provided to the `service()` argument and fetches the Document

--- a/twilly/src/sync/listitems.rs
+++ b/twilly/src/sync/listitems.rs
@@ -122,7 +122,7 @@ pub struct ListItems<'a, 'b> {
     pub list_sid: &'b str,
 }
 
-impl<'a, 'b> ListItems<'a, 'b> {
+impl ListItems<'_, '_> {
     /// [Creates a Sync List Item](https://www.twilio.com/docs/sync/api/listitem-resource#create-a-listitem-resource)
     ///
     /// Creates a Sync List Item with the provided parameters.
@@ -202,7 +202,7 @@ pub struct ListItem<'a, 'b> {
     pub index: &'b u32,
 }
 
-impl<'a, 'b> ListItem<'a, 'b> {
+impl ListItem<'_, '_> {
     /// [Gets a Sync List Item](https://www.twilio.com/docs/sync/api/listitem-resource#fetch-a-listitem-resource)
     ///
     /// Targets the Sync Service provided to the `service()` argument, the List provided to the `list()`

--- a/twilly/src/sync/lists.rs
+++ b/twilly/src/sync/lists.rs
@@ -190,7 +190,7 @@ impl<'a, 'b> List<'a, 'b> {
     /// Functions relating to a known Sync List Item.
     ///
     /// Takes in the key of the Sync List Item to perform actions against.
-    pub fn listitem(&'a self, index: &'b u32) -> ListItem {
+    pub fn listitem(&self, index: &'b u32) -> ListItem {
         ListItem {
             client: self.client,
             service_sid: self.service_sid,
@@ -200,7 +200,7 @@ impl<'a, 'b> List<'a, 'b> {
     }
 
     /// General Sync Map Item functions.
-    pub fn listitems(&'a self) -> ListItems {
+    pub fn listitems(&self) -> ListItems {
         ListItems {
             client: self.client,
             service_sid: self.service_sid,

--- a/twilly/src/sync/lists.rs
+++ b/twilly/src/sync/lists.rs
@@ -66,7 +66,7 @@ pub struct Lists<'a, 'b> {
     pub service_sid: &'b str,
 }
 
-impl<'a, 'b> Lists<'a, 'b> {
+impl Lists<'_, '_> {
     /// [Creates a Sync List resource](https://www.twilio.com/docs/sync/api/list-resource#create-a-list-resource)
     ///
     /// Creates a Sync List resource with the provided parameters.
@@ -130,7 +130,7 @@ pub struct List<'a, 'b> {
     pub sid: &'b str,
 }
 
-impl<'a, 'b> List<'a, 'b> {
+impl<'b> List<'_, 'b> {
     /// [Gets a Sync List](https://www.twilio.com/docs/sync/api/list-resource#fetch-a-list-resource)
     ///
     /// Targets the Sync Service provided to the `service()` argument and fetches the List

--- a/twilly/src/sync/mapitems.rs
+++ b/twilly/src/sync/mapitems.rs
@@ -130,7 +130,7 @@ pub struct MapItems<'a, 'b> {
     pub map_sid: &'b str,
 }
 
-impl<'a, 'b> MapItems<'a, 'b> {
+impl MapItems<'_, '_> {
     /// [Creates a Sync Map Item](https://www.twilio.com/docs/sync/api/map-item-resource#create-a-mapitem-resource)
     ///
     /// Creates a Sync Map Item with the provided parameters.
@@ -211,7 +211,7 @@ pub struct MapItem<'a, 'b> {
     pub key: &'b str,
 }
 
-impl<'a, 'b> MapItem<'a, 'b> {
+impl MapItem<'_, '_> {
     /// [Gets a Sync Map Item](https://www.twilio.com/docs/sync/api/map-item-resource#fetch-a-mapitem-resource)
     ///
     /// Targets the Sync Service provided to the `service()` argument, the Map provided to the `map()`

--- a/twilly/src/sync/maps.rs
+++ b/twilly/src/sync/maps.rs
@@ -66,7 +66,7 @@ pub struct Maps<'a, 'b> {
     pub service_sid: &'b str,
 }
 
-impl<'a, 'b> Maps<'a, 'b> {
+impl Maps<'_, '_> {
     /// [Creates a Sync Map resource](https://www.twilio.com/docs/sync/api/map-resource#create-a-syncmap-resource)
     ///
     /// Creates a Sync Map resource with the provided parameters.
@@ -130,7 +130,7 @@ pub struct Map<'a, 'b> {
     pub sid: &'b str,
 }
 
-impl<'a, 'b> Map<'a, 'b> {
+impl<'b> Map<'_, 'b> {
     /// [Gets a Sync Map](https://www.twilio.com/docs/sync/api/map-resource#fetch-a-syncmap-resource)
     ///
     /// Targets the Sync Service provided to the `service()` argument and fetches the Map

--- a/twilly/src/sync/maps.rs
+++ b/twilly/src/sync/maps.rs
@@ -190,7 +190,7 @@ impl<'a, 'b> Map<'a, 'b> {
     /// Functions relating to a known Sync Map Item.
     ///
     /// Takes in the key of the Sync Map Item to perform actions against.
-    pub fn mapitem(&'a self, key: &'b str) -> MapItem {
+    pub fn mapitem(&self, key: &'b str) -> MapItem {
         MapItem {
             client: self.client,
             service_sid: self.service_sid,
@@ -200,7 +200,7 @@ impl<'a, 'b> Map<'a, 'b> {
     }
 
     /// General Sync Map Item functions.
-    pub fn mapitems(&'a self) -> MapItems {
+    pub fn mapitems(&self) -> MapItems {
         MapItems {
             client: self.client,
             service_sid: self.service_sid,

--- a/twilly/src/sync/services.rs
+++ b/twilly/src/sync/services.rs
@@ -194,7 +194,7 @@ impl<'a, 'b> Service<'a, 'b> {
     /// Functions relating to a known Sync Document.
     ///
     /// Takes in the SID of the Sync Document to perform actions against.
-    pub fn document(&'a self, sid: &'b str) -> Document {
+    pub fn document(&self, sid: &'b str) -> Document {
         Document {
             client: self.client,
             service_sid: self.sid,
@@ -203,7 +203,7 @@ impl<'a, 'b> Service<'a, 'b> {
     }
 
     /// General Sync Document functions.
-    pub fn documents(&'a self) -> Documents {
+    pub fn documents(&self) -> Documents {
         Documents {
             client: self.client,
             service_sid: self.sid,
@@ -213,7 +213,7 @@ impl<'a, 'b> Service<'a, 'b> {
     /// Functions relating to a known Sync Map.
     ///
     /// Takes in the SID of the Sync Map to perform actions against.
-    pub fn map(&'a self, sid: &'b str) -> Map {
+    pub fn map(&self, sid: &'b str) -> Map {
         Map {
             client: self.client,
             service_sid: self.sid,
@@ -222,7 +222,7 @@ impl<'a, 'b> Service<'a, 'b> {
     }
 
     /// General Sync Map functions.
-    pub fn maps(&'a self) -> Maps {
+    pub fn maps(&self) -> Maps {
         Maps {
             client: self.client,
             service_sid: self.sid,
@@ -230,7 +230,7 @@ impl<'a, 'b> Service<'a, 'b> {
     }
 
     /// General Sync List functions.
-    pub fn lists(&'a self) -> Lists {
+    pub fn lists(&self) -> Lists {
         Lists {
             client: self.client,
             service_sid: self.sid,
@@ -240,7 +240,7 @@ impl<'a, 'b> Service<'a, 'b> {
     /// Functions relating to a known Sync List.
     ///
     /// Takes in the SID of the Sync List to perform actions against.
-    pub fn list(&'a self, sid: &'b str) -> List {
+    pub fn list(&self, sid: &'b str) -> List {
         List {
             client: self.client,
             service_sid: self.sid,

--- a/twilly/src/sync/services.rs
+++ b/twilly/src/sync/services.rs
@@ -76,7 +76,7 @@ pub struct Services<'a> {
     pub client: &'a Client,
 }
 
-impl<'a> Services<'a> {
+impl Services<'_> {
     /// [Creates a Sync Service](https://www.twilio.com/docs/sync/api/service#create-a-service-resource)
     ///
     /// Creates a Sync Service resource with the provided parameters.
@@ -139,7 +139,7 @@ pub struct Service<'a, 'b> {
     pub sid: &'b str,
 }
 
-impl<'a, 'b> Service<'a, 'b> {
+impl<'b> Service<'_, 'b> {
     /// [Gets a Sync Service](https://www.twilio.com/docs/sync/api/service#fetch-a-service-resource)
     ///
     /// Fetches the Sync Service provided to the `Service()`.

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -218,11 +218,11 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                             .iter()
                                             .map(|conv| match &conv.unique_name {
                                                 Some(unique_name) => format!(
-                                                    "({}) {} - {}",
+                                                    "({}) {} - {:?}",
                                                     conv.sid, unique_name, conv.state
                                                 ),
                                                 None => {
-                                                    format!("{} - {}", conv.sid, conv.state)
+                                                    format!("{} - {:?}", conv.sid, conv.state)
                                                 }
                                             })
                                             .collect::<Vec<String>>(),
@@ -250,7 +250,15 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                         break;
                                     };
 
-                                    match selected_conversation.state {
+                                    if selected_conversation.state.is_none() {
+                                        eprintln!(
+                                            "Conversation {} had an unknown state.",
+                                            selected_conversation.sid
+                                        );
+                                        break;
+                                    }
+
+                                    match selected_conversation.state.clone().unwrap() {
                                         State::Closed => loop {
                                             if let Some(conversation_action) =
                                                 get_action_choice_from_user(

--- a/twilly_cli/src/conversation.rs
+++ b/twilly_cli/src/conversation.rs
@@ -217,12 +217,11 @@ pub async fn choose_conversation_action(twilio: &Client) {
                                         conversations
                                             .iter()
                                             .map(|conv| match &conv.unique_name {
-                                                Some(unique_name) => format!(
-                                                    "({}) {} - {:?}",
-                                                    conv.sid, unique_name, conv.state
-                                                ),
+                                                Some(unique_name) => {
+                                                    format!("({}) {}", unique_name, conv)
+                                                }
                                                 None => {
-                                                    format!("{} - {:?}", conv.sid, conv.state)
+                                                    format!("{}", conv)
                                                 }
                                             })
                                             .collect::<Vec<String>>(),


### PR DESCRIPTION
This PR resolves an issue with functionality around fetching and manipulating conversations via Twilly. 

The `Conversation` struct which describes the data returned by Twilio incorrectly labeled `messaging_service_sid`, `state`, and `timers` properties. Despite `state` & `timers` have default values at creation of `active` and `{}` respectively, it appears that these values can get into a null state (I have not been able to reproduce this).

This PR recognises such a state to avoid deserialization errors during the fetch.